### PR TITLE
Feat/RTENU-113 dropdown navigation bar

### DIFF
--- a/packages/frontend/src/components/NavBar/DesktopDrawer.tsx
+++ b/packages/frontend/src/components/NavBar/DesktopDrawer.tsx
@@ -80,8 +80,9 @@ export const DesktopDrawerWrapper = styled(MuiDrawer)<DrawerWrapperProps>(({ the
 
       // Logout is the last list item
       '& li:last-child': {
-        position: 'fixed',
-        bottom: '16px',
+        // TODO: Logout should always be placed in bottom
+        // position: 'fixed',
+        // bottom: '16px',
         width: open ? `${drawerWidth}px` : `calc(${theme.spacing(8)} + 1px)`,
         '& .MuiListItemIcon-root': {
           color: Colors.darkblue,

--- a/packages/frontend/src/components/NavBar/MenuItems.tsx
+++ b/packages/frontend/src/components/NavBar/MenuItems.tsx
@@ -48,6 +48,7 @@ const fetchMaterialClass = (): IMenuItem[] => {
         return {
           key: item,
           primary: item,
+          // TODO: create page components. Route names may be changed
           to: `/${item}`,
         };
       }),

--- a/packages/frontend/src/components/NavBar/MenuItems.tsx
+++ b/packages/frontend/src/components/NavBar/MenuItems.tsx
@@ -1,14 +1,59 @@
 import InfoIcon from '@mui/icons-material/Info';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { Typography } from '@mui/material';
+import SsidChartIcon from '@mui/icons-material/SsidChart';
+import DirectionsIcon from '@mui/icons-material/Directions';
+import SubwayIcon from '@mui/icons-material/Subway';
+import ShieldIcon from '@mui/icons-material/Shield';
+import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
+import WidgetsIcon from '@mui/icons-material/Widgets';
+import BrowserNotSupportedIcon from '@mui/icons-material/BrowserNotSupported';
+
 import { Routes } from '../../constants/Routes';
+import categoryData from '../../assets/data/aineistoluokka.json';
 
 export interface IMenuItem {
   key: string;
   primary: string | JSX.Element;
-  icon: JSX.Element;
-  to: string;
+  icon?: JSX.Element;
+  to?: string;
+  children?: any;
 }
+
+const fetchMaterialClass = (): IMenuItem[] => {
+  const loadIcons = (category: string) => {
+    switch (category) {
+      case 'Kaaviot':
+        return <SsidChartIcon />;
+      case 'Liikennöinti':
+        return <DirectionsIcon />;
+      case 'Taitorakenteet':
+        return <SubwayIcon />;
+      case 'Turvalaitteet':
+        return <ShieldIcon />;
+      case 'Yhteystiedot':
+        return <AlternateEmailIcon />;
+      case 'Muut':
+        return <WidgetsIcon />;
+      default:
+        return <BrowserNotSupportedIcon />;
+    }
+  };
+  return categoryData.map((data) => {
+    return {
+      key: data.category,
+      primary: data.category,
+      icon: loadIcons(data.category),
+      children: data.items.map((item) => {
+        return {
+          key: item,
+          primary: item,
+          to: `/${item}`,
+        };
+      }),
+    };
+  });
+};
 
 export const MenuItems: IMenuItem[] = [
   {
@@ -17,6 +62,7 @@ export const MenuItems: IMenuItem[] = [
     icon: <InfoIcon />,
     to: Routes.LANDING,
   },
+  ...fetchMaterialClass(),
   // Logout should always be the last menu item
   {
     key: 'Logout',

--- a/packages/frontend/src/components/NavBar/MenuList.tsx
+++ b/packages/frontend/src/components/NavBar/MenuList.tsx
@@ -1,5 +1,7 @@
-import { List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import { useState } from 'react';
+import { Colors } from '../../constants/Colors';
 
 import { IMenuItem, MenuItems } from './MenuItems';
 
@@ -8,20 +10,52 @@ type MenuListProps = {
 };
 
 export const MenuList = ({ open }: MenuListProps) => {
-  const navigate = useNavigate();
+  const resetMenu = () => {
+    let menuData = {};
+    MenuItems.forEach((item: IMenuItem) => {
+      menuData = {
+        ...menuData,
+        [item.key]: false,
+      };
+    });
+    return menuData;
+  };
+
+  const [menu, setMenu] = useState<{ [key: string]: boolean }>(resetMenu);
+
+  const handleClick = (key: string) => {
+    setMenu({ ...menu, [key]: !menu[key] });
+  };
+
   return (
-    <List>
+    <>
       {MenuItems.map((item: IMenuItem) => {
-        const { key, primary, icon, to } = item;
+        const { key, primary, icon, to, children } = item;
         return (
-          <ListItem key={key} disablePadding onClick={() => navigate(to)}>
-            <ListItemButton>
-              <ListItemIcon>{icon}</ListItemIcon>
-              <ListItemText primary={primary} sx={{ opacity: open ? 1 : 0 }} />
-            </ListItemButton>
-          </ListItem>
+          <>
+            <ListItem disablePadding key={key} alignItems="flex-start" onClick={() => handleClick(key)}>
+              <ListItemButton href={to ? to : ''}>
+                <ListItemIcon>{icon}</ListItemIcon>
+                <ListItemText primary={primary} sx={{ opacity: open ? 1 : 0 }} />
+                {children && (menu[key] ? <ExpandLess /> : <ExpandMore />)}
+              </ListItemButton>
+            </ListItem>
+            {children &&
+              menu[key] &&
+              children.map((child: IMenuItem) => {
+                return (
+                  <ListItemButton
+                    sx={{ pl: 9, whiteSpace: 'normal', flexGrow: 'unset', backgroundColor: Colors.lightgrey }}
+                    key={child.key}
+                    href={child.to ? child.to : ''}
+                  >
+                    <ListItemText primary={child.primary} />
+                  </ListItemButton>
+                );
+              })}
+          </>
         );
       })}
-    </List>
+    </>
   );
 };

--- a/packages/frontend/src/components/NavBar/MiniDrawer.tsx
+++ b/packages/frontend/src/components/NavBar/MiniDrawer.tsx
@@ -43,8 +43,9 @@ export const MiniDrawerWrapper = styled(MuiDrawer)<DrawerWrapperProps>(({ theme,
     },
     // Logout is the last list item
     '& li:last-child': {
-      position: 'fixed',
-      bottom: '16px',
+      // TODO: Logout should always be placed in bottom
+      // position: 'fixed',
+      // bottom: '16px',
       width: open ? `${drawerWidth}px` : `calc(${theme.spacing(8)} + 1px)`,
       '& .MuiListItemIcon-root': {
         color: Colors.darkblue,


### PR DESCRIPTION
**Done:**
- Display aineistoluokka in navigation bar

**To-do:** 
- Children's routes are undefined so result in not found page -> create pages for categories' children
- Logout's position was set to fixed/absolute, however, when open the dropdown list, logout doesn't move to the new bottom position 