### PR TITLE
fix: Lambda building when not doing local stack

### DIFF
--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -14,7 +14,7 @@ import { NodejsFunction, BundlingOptions, OutputFormat } from 'aws-cdk-lib/aws-l
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { ListenerAction, ListenerCondition } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as path from 'path';
-import { isDevelopmentMainStack } from './utils';
+import { isDevelopmentMainStack, isLocalStack } from './utils';
 import { RataExtraBastionStack } from './rataextra-bastion';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
@@ -99,6 +99,7 @@ export class RataExtraBackendStack extends NestedStack {
       },
       bundling: {
         nodeModules: ['prisma', '@prisma/client'],
+        forceDockerBundling: !isLocalStack(rataExtraEnv),
         format: OutputFormat.ESM,
         platform: 'node',
         target: 'node16',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,6 +23,12 @@ export const isProductionStack = (stackId: string, rataExtraEnv: RataExtraEnviro
  */
 export const isFeatOrLocalStack = (rataExtraEnv: RataExtraEnvironment) =>
   rataExtraEnv === ENVIRONMENTS.feat || rataExtraEnv === ENVIRONMENTS.local;
+
+/**
+ * Returns whether the stack is a local stack
+ */
+export const isLocalStack = (rataExtraEnv: RataExtraEnvironment) => rataExtraEnv === ENVIRONMENTS.local;
+
 /**
  * Returns whether the stack is one of the two permanent RataExtra stacks
  * - development main stack that corresponds to development main branch in Github


### PR DESCRIPTION
Might be a temporary fix, but this should get the Prisma stuff working for now.
When deploying feat-stacks, it'll do it the slow way, but at least stacks with local env use bundling.