### PR TITLE
clear cookies before logout

### DIFF
--- a/packages/frontend/src/assets/locales/fi/common.json
+++ b/packages/frontend/src/assets/locales/fi/common.json
@@ -13,5 +13,8 @@
   },
   "error": {
     "500": "Jokin meni pieleen!"
+  },
+  "loading": {
+    "logging_out": "Kirjaudutaan ulos..."
   }
 }

--- a/packages/frontend/src/constants/Routes.ts
+++ b/packages/frontend/src/constants/Routes.ts
@@ -4,5 +4,6 @@ export const Routes = {
   NOT_FOUND: '/*',
   LANDING: '/etusivu',
   SEARCH_RESULT: '/haku',
-  LOGOUT: '/sso/logout?auth=1',
+  LOGOUT: 'logout',
+  LOGOUT_REDIRECT: '/sso/logout?auth=1',
 };

--- a/packages/frontend/src/pages/LoggingOut/index.tsx
+++ b/packages/frontend/src/pages/LoggingOut/index.tsx
@@ -1,0 +1,5 @@
+import { t } from 'i18next';
+
+export const LoggingOut = () => {
+  return <div>{t('common:loading.logging_out')}</div>;
+};

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouteObject } from 'react-router-dom';
+import { createBrowserRouter, RouteObject, redirect } from 'react-router-dom';
 
 import { Landing } from './pages/Landing';
 import { Routes } from './constants/Routes';
@@ -32,6 +32,19 @@ const routes: RouteObject[] = [
       // TODO: throw error if user has no permission
     },
     children: [],
+  },
+  {
+    path: Routes.LOGOUT,
+    element: <div>LOGGING OUT...</div>,
+    errorElement: <RootBoundary />, // Send user here whenever error is thrown
+    loader: async () => {
+      console.log('Logging out');
+      document.cookie = 'Return=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      // check if cookie exists then redirect to /
+      if (document.cookie.indexOf('Return') === -1) {
+        return redirect(Routes.LOGOUT_REDIRECT);
+      }
+    },
   },
 ];
 

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -5,6 +5,7 @@ import { Routes } from './constants/Routes';
 import { ProtectedPage } from './pages/ProtectedPage';
 import { RootBoundary } from './components/RootBoundary';
 import { SearchResult } from './pages/Search/SearchResult';
+import { LoggingOut } from './pages/LoggingOut';
 
 const routes: RouteObject[] = [
   {
@@ -35,15 +36,17 @@ const routes: RouteObject[] = [
   },
   {
     path: Routes.LOGOUT,
-    element: <div>LOGGING OUT...</div>,
+    element: <LoggingOut></LoggingOut>,
     errorElement: <RootBoundary />, // Send user here whenever error is thrown
     loader: async () => {
-      console.log('Logging out');
       document.cookie = 'Return=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-      // check if cookie exists then redirect to /
-      if (document.cookie.indexOf('Return') === -1) {
-        return redirect(Routes.LOGOUT_REDIRECT);
+      // check if cookie is removed
+      if (document.cookie.indexOf('Return') !== -1) {
+        // TODO: What do we do if we ever get here? Now user might get stuck.
+        throw new Error('Could not remove cookie.');
       }
+      // redirect to logout url after succesfull cookie removal
+      return redirect(Routes.LOGOUT_REDIRECT);
     },
   },
 ];


### PR DESCRIPTION
"Return" cookie keeps already authenticated user out of login form. This causes problem when unauthenticated user tries navigate login form but we keep sending user back to frontend app.

- Remove "Return" cookie before logout invocation.
