### PR TITLE
Fix/RTENU-109 filter search functionality

### DIFF
--- a/packages/frontend/src/components/Search/FilterSearch.tsx
+++ b/packages/frontend/src/components/Search/FilterSearch.tsx
@@ -10,7 +10,7 @@ import { DatePicker } from '@mui/x-date-pickers';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 
-import { ESearchParameterName, FilterSearchData, IItem } from './FilterSearchData';
+import { SearchParameterName, FilterSearchData, IItem } from './FilterSearchData';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { Colors } from '../../constants/Colors';
 import { SearchContext } from '../../contexts/SearchContext';
@@ -36,7 +36,7 @@ const FilterSearchItem = (props: IFilterSearchItem) => {
     setOpen((prevState: boolean) => !prevState);
   };
 
-  const isDefaultChecked = (name: ESearchParameterName, value: string) => {
+  const isDefaultChecked = (name: SearchParameterName, value: string) => {
     return checkedList[name]?.indexOf(value) !== -1;
   };
 
@@ -78,7 +78,7 @@ export const FilterSearch = ({ openFilter, toggleFilter }: FilterSearchProps) =>
   const [from, setFrom] = useState<Date | null>(years[0] ? years[0] : null);
   const [to, setTo] = useState<Date | null>(years[1] ? years[1] : null);
 
-  const [checkboxes, setCheckboxes] = useState<{ [name in ESearchParameterName]: string[] }>(checkedList);
+  const [checkboxes, setCheckboxes] = useState<{ [name in SearchParameterName]: string[] }>(checkedList);
 
   const clearFilters = () => {
     setFrom(null);
@@ -86,7 +86,7 @@ export const FilterSearch = ({ openFilter, toggleFilter }: FilterSearchProps) =>
     // TODO: remove all check boxes
   };
 
-  const handleCheckBoxes = (name: ESearchParameterName, value: EMimeType) => {
+  const handleCheckBoxes = (name: SearchParameterName, value: EMimeType) => {
     const index = checkboxes[name].indexOf(value);
     if (index === -1) {
       setCheckboxes({ ...checkboxes, [name]: [...checkboxes[name], value] });

--- a/packages/frontend/src/components/Search/FilterSearchData.ts
+++ b/packages/frontend/src/components/Search/FilterSearchData.ts
@@ -2,7 +2,7 @@ import { flatMapByKey } from '../../utils/helpers';
 import categoryData from '../../assets/data/aineistoluokka.json';
 import { FileFormats, FinnishRegions } from '../../constants/Data';
 
-export enum ESearchParameterName {
+export enum SearchParameterName {
   MIME = 'mime',
   REGION = 'region',
   MATERIAL_CLASS = 'materialClass',
@@ -10,7 +10,7 @@ export enum ESearchParameterName {
 
 export interface IItem {
   name: string;
-  type: ESearchParameterName;
+  type: SearchParameterName;
   items: string[];
 }
 
@@ -19,17 +19,17 @@ export interface IItem {
 export const FilterSearchData: IItem[] = [
   {
     name: 'Muoto',
-    type: ESearchParameterName.MIME,
+    type: SearchParameterName.MIME,
     items: FileFormats,
   },
   {
     name: 'Alue',
-    type: ESearchParameterName.REGION,
+    type: SearchParameterName.REGION,
     items: FinnishRegions,
   },
   {
     name: 'Aineistoluokka',
-    type: ESearchParameterName.MATERIAL_CLASS,
+    type: SearchParameterName.MATERIAL_CLASS,
     items: flatMapByKey(categoryData, 'items'),
   },
 ];

--- a/packages/frontend/src/components/Tags/index.tsx
+++ b/packages/frontend/src/components/Tags/index.tsx
@@ -1,19 +1,19 @@
 import { Chip, Stack } from '@mui/material';
 import { useContext } from 'react';
-import { format } from 'date-fns';
 
 import { SearchContext } from '../../contexts/SearchContext';
+import { formatYear } from '../../utils/helpers';
 
 export const Tags = () => {
   const { years, checkedList } = useContext(SearchContext);
-  const fromYear = years[0] ? format(years[0], 'yyyy') : '';
-  const toYear = years[1] ? format(years[1], 'yyyy') : '';
+  const fromYear = formatYear(years[0]);
+  const toYear = formatYear(years[1]);
   let yearRange = '';
   if (fromYear) {
     yearRange += fromYear;
-  }
-  if (toYear) {
-    yearRange += `- ${toYear}`;
+    if (fromYear < toYear && toYear) {
+      yearRange += `- ${toYear}`;
+    }
   }
 
   return (

--- a/packages/frontend/src/contexts/SearchContext.tsx
+++ b/packages/frontend/src/contexts/SearchContext.tsx
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { SearchParameterName } from '../components/Search/FilterSearchData';

--- a/packages/frontend/src/contexts/SearchContext.tsx
+++ b/packages/frontend/src/contexts/SearchContext.tsx
@@ -1,13 +1,15 @@
+import { format } from 'date-fns';
 import React, { useState } from 'react';
-import { ESearchParameterName } from '../components/Search/FilterSearchData';
+import { useSearchParams } from 'react-router-dom';
+import { SearchParameterName } from '../components/Search/FilterSearchData';
 
 export const SearchContext = React.createContext({
   query: '',
   queryHandler: (_: string) => {},
   checkedList: {
-    [ESearchParameterName.MIME]: [''],
-    [ESearchParameterName.REGION]: [''],
-    [ESearchParameterName.MATERIAL_CLASS]: [''],
+    [SearchParameterName.MIME]: [''],
+    [SearchParameterName.REGION]: [''],
+    [SearchParameterName.MATERIAL_CLASS]: [''],
   },
   checkedListHandler: (checkboxes: any) => {},
   years: [null, null],
@@ -15,12 +17,15 @@ export const SearchContext = React.createContext({
 });
 
 export const SearchContextProvider = (props: any) => {
-  const [query, setQuery] = useState('');
+  const [searchParams] = useSearchParams();
+  const [query, setQuery] = useState<string>(() => {
+    return searchParams.get('query') || '';
+  });
   const [years, setYears] = useState<any[]>([]);
-  const [checkedList, setCheckedList] = useState<{ [name in ESearchParameterName]: string[] }>({
-    [ESearchParameterName.MIME]: [],
-    [ESearchParameterName.REGION]: [],
-    [ESearchParameterName.MATERIAL_CLASS]: [],
+  const [checkedList, setCheckedList] = useState<{ [name in SearchParameterName]: string[] }>({
+    [SearchParameterName.MIME]: [],
+    [SearchParameterName.REGION]: [],
+    [SearchParameterName.MATERIAL_CLASS]: [],
   });
 
   const queryHandler = (query: string) => {

--- a/packages/frontend/src/hooks/query/Search.ts
+++ b/packages/frontend/src/hooks/query/Search.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { SearchParameterName } from '../../components/Search/FilterSearchData';
 import { ExtendedSearchParameterName, TSearchParamaterBody } from '../../types/types.d';
 
-type TAlfrescoSearchProps = {
+export type TAlfrescoSearchProps = {
   term: string | null;
   from?: string | number;
   to?: string | number;

--- a/packages/frontend/src/hooks/query/Search.ts
+++ b/packages/frontend/src/hooks/query/Search.ts
@@ -1,25 +1,51 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import { SearchParameterName } from '../../components/Search/FilterSearchData';
+import { ExtendedSearchParameterName, TSearchParamaterBody } from '../../types/types.d';
 
-export const usePostAlfrescoSearch = (term: string | null) => {
+type TAlfrescoSearchProps = {
+  term: string | null;
+  from?: string | number;
+  to?: string | number;
+  fileTypes?: string[];
+};
+
+const getSearchBody = ({ term, from, to, fileTypes }: TAlfrescoSearchProps) => {
+  let body: { searchParameters: TSearchParamaterBody[] } = { searchParameters: [] };
+  if (term) {
+    body.searchParameters.push({
+      parameterName: ExtendedSearchParameterName.NAME,
+      fileName: term,
+    });
+  }
+  if (from) {
+    body.searchParameters.push({
+      parameterName: ExtendedSearchParameterName.MODIFIED,
+      from: from,
+      to: to,
+    });
+  }
+  if (fileTypes?.length) {
+    body.searchParameters.push({
+      parameterName: SearchParameterName.MIME,
+      fileTypes: fileTypes,
+    });
+  }
+  return body;
+};
+
+export const usePostAlfrescoSearch = (props: TAlfrescoSearchProps) => {
+  const { term } = props;
+
   return useQuery({
     enabled: Boolean(term),
-    queryKey: ['alfresco-search', term],
+    queryKey: ['alfresco-search', props],
     queryFn: async () => {
-      const body = {
-        searchParameters: [
-          {
-            parameterName: 'name',
-            fileName: term,
-          },
-        ],
-      };
+      const body = getSearchBody(props);
       const response = await axios.post('/api/alfresco/search', body);
       return response.data;
     },
     onSuccess: (res) => res,
-    // temporary
-    // TODO: throw error in toaster
     onError: (err: Error) => {
       console.log(err);
       return err;

--- a/packages/frontend/src/hooks/query/Search.ts
+++ b/packages/frontend/src/hooks/query/Search.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { SearchParameterName } from '../../components/Search/FilterSearchData';
-import { ExtendedSearchParameterName, TSearchParamaterBody } from '../../types/types.d';
+import { ExtendedSearchParameterName, TSearchParameterBody } from '../../types/types.d';
 
 export type TAlfrescoSearchProps = {
   term: string | null;
@@ -11,7 +11,7 @@ export type TAlfrescoSearchProps = {
 };
 
 const getSearchBody = ({ term, from, to, fileTypes }: TAlfrescoSearchProps) => {
-  let body: { searchParameters: TSearchParamaterBody[] } = { searchParameters: [] };
+  let body: { searchParameters: TSearchParameterBody[] } = { searchParameters: [] };
   if (term) {
     body.searchParameters.push({
       parameterName: ExtendedSearchParameterName.NAME,

--- a/packages/frontend/src/pages/Search/NodeItem.tsx
+++ b/packages/frontend/src/pages/Search/NodeItem.tsx
@@ -42,7 +42,11 @@ export const NodeItem = ({ node, row }: any) => {
       sx={{ paddingBottom: '18px', backgroundColor: row % 2 ? Colors.lightgrey : Colors.white }}
     >
       <Grid item mobile={1} tablet={0.5} desktop={0.5}>
-        <Box component="img" src={matchMimeType(content.mimeType)} alt="Logo" />
+        <Box
+          component="img"
+          src={content && content.mimeType ? matchMimeType(content.mimeType) : NodeTypes.other}
+          alt="Logo"
+        />
       </Grid>
       <Grid item mobile={11} tablet={11.5} desktop={11.5}>
         <Typography variant="body1">{name}</Typography>

--- a/packages/frontend/src/pages/Search/SearchResult.tsx
+++ b/packages/frontend/src/pages/Search/SearchResult.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Tags } from '../../components/Tags';
 import { ContainerWrapper } from '../Landing/index.styles';
 import { NodeItem } from './NodeItem';
-import { usePostAlfrescoSearch } from '../../hooks/query/Search';
+import { TAlfrescoSearchProps, usePostAlfrescoSearch } from '../../hooks/query/Search';
 import { useContext } from 'react';
 import { SearchContext } from '../../contexts/SearchContext';
 import { formatYear } from '../../utils/helpers';
@@ -17,7 +17,7 @@ export const SearchResult = () => {
   const query = searchParams.get('query');
   const searchContext = useContext(SearchContext);
   const { years, checkedList } = searchContext;
-  const searchParameter = {
+  const searchParameter: TAlfrescoSearchProps = {
     term: query,
     from: formatYear(years[0]),
     to: formatYear(years[1]),

--- a/packages/frontend/src/pages/Search/SearchResult.tsx
+++ b/packages/frontend/src/pages/Search/SearchResult.tsx
@@ -1,5 +1,4 @@
 import { Alert, Typography } from '@mui/material';
-import { useSearchParams } from 'react-router-dom';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useTranslation } from 'react-i18next';
 
@@ -7,18 +6,30 @@ import { Tags } from '../../components/Tags';
 import { ContainerWrapper } from '../Landing/index.styles';
 import { NodeItem } from './NodeItem';
 import { usePostAlfrescoSearch } from '../../hooks/query/Search';
+import { useContext } from 'react';
+import { SearchContext } from '../../contexts/SearchContext';
+import { formatYear } from '../../utils/helpers';
+import { useSearchParams } from 'react-router-dom';
 
 export const SearchResult = () => {
   const { t } = useTranslation(['search', 'common']);
   const [searchParams] = useSearchParams();
   const query = searchParams.get('query');
+  const searchContext = useContext(SearchContext);
+  const { years, checkedList } = searchContext;
+  const searchParameter = {
+    term: query,
+    from: formatYear(years[0]),
+    to: formatYear(years[1]),
+    fileTypes: checkedList.mime,
+  };
 
-  const { isLoading, isError, error, data } = usePostAlfrescoSearch(query);
+  const { isLoading, isError, error, data } = usePostAlfrescoSearch(searchParameter);
 
   if (isLoading) {
     return (
       <ContainerWrapper>
-        <CircularProgress />;
+        <CircularProgress />
       </ContainerWrapper>
     );
   }

--- a/packages/frontend/src/types/types.d.ts
+++ b/packages/frontend/src/types/types.d.ts
@@ -46,4 +46,4 @@ type TMimeSearchParameter = {
   fileTypes: string[];
 };
 
-type TSearchParamaterBody = TNameSearchParameter | TModifiedSearchParameter | TMimeSearchParameter;
+type TSearchParameterBody = TNameSearchParameter | TModifiedSearchParameter | TMimeSearchParameter;

--- a/packages/frontend/src/types/types.d.ts
+++ b/packages/frontend/src/types/types.d.ts
@@ -24,3 +24,26 @@ declare module '@mui/material/styles' {
 declare module '@emotion/react' {
   export interface Theme extends MaterialTheme {}
 }
+
+export enum ExtendedSearchParameterName {
+  NAME = 'name',
+  MODIFIED = 'modified',
+}
+
+type TNameSearchParameter = {
+  parameterName: ExtendedSearchParameterName.NAME;
+  fileName: string;
+};
+
+type TModifiedSearchParameter = {
+  parameterName: ExtendedSearchParameterName.MODIFIED;
+  from: string | number;
+  to?: string | number;
+};
+
+type TMimeSearchParameter = {
+  parameterName: SearchParameterName.MIME;
+  fileTypes: string[];
+};
+
+type TSearchParamaterBody = TNameSearchParameter | TModifiedSearchParameter | TMimeSearchParameter;

--- a/packages/frontend/src/utils/helpers.ts
+++ b/packages/frontend/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { FileSizeUnit, LocaleLang, LocaleUnit } from '../constants/Units';
 
 /**
@@ -50,4 +51,8 @@ export const flatMapByKey = (array: Array<any>, key: any): Array<any> => {
 export const getLocaleByteUnit = (unitStr: string, locale: LocaleLang) => {
   const unitParts = unitStr.split(' ');
   return unitParts[0] + ' ' + (LocaleUnit[locale][unitParts[1] as keyof FileSizeUnit] || unitParts[1]);
+};
+
+export const formatYear = (date: Date | null) => {
+  return date ? format(date, 'yyyy') : '';
 };


### PR DESCRIPTION
**DONE**
- null check for entry's content property. Some entries don't have content which was previously accessed to get `mimeType`. This resulted in "Something went wrong"
- Construct request body including search term and filter data (year range + file format) for axios
- Some fixes on data types

**TODO**
- Year Picker (disabled past years)
- Form data validation (if any)
- Pagination
- Clickable recent searches
- Downloadable files 

