### PR TITLE
Fix/RTENU-109 filter search functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "concurrently": "^7.4.0",
         "constructs": "^10.0.0",
         "date-fns": "^2.29.3",
+        "lodash": "^4.17.21",
         "pretty-bytes": "^6.0.0"
       },
       "devDependencies": {
+        "@types/lodash": "^4.14.191",
         "@types/node": "^18.7.23",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
@@ -8373,6 +8375,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/jwk-to-pem/-/jwk-to-pem-2.0.1.tgz",
       "integrity": "sha512-QXmRPhR/LPzvXBHTPfG2BBfMTkNLUD7NyRcPft8m5xFCeANa1BZyLgT0Gw+OxdWx6i1WCpT27EqyggP4UUHMrA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -35070,6 +35078,12 @@
       "integrity": "sha512-QXmRPhR/LPzvXBHTPfG2BBfMTkNLUD7NyRcPft8m5xFCeANa1BZyLgT0Gw+OxdWx6i1WCpT27EqyggP4UUHMrA==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -47925,7 +47939,7 @@
         "@types/jwk-to-pem": "^2.0.1",
         "@types/mocha": "^10.0.0",
         "aws-lambda": "^1.0.7",
-        "aws-sdk": "*",
+        "aws-sdk": "^2.1278.0",
         "axios": "^1.1.3",
         "chai": "^4.3.6",
         "chai-http": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
     "concurrently": "^7.4.0",
     "constructs": "^10.0.0",
     "date-fns": "^2.29.3",
+    "lodash": "^4.17.21",
     "pretty-bytes": "^6.0.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.191",
     "@types/node": "^18.7.23",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",

--- a/packages/frontend/src/pages/Search/NodeItem.tsx
+++ b/packages/frontend/src/pages/Search/NodeItem.tsx
@@ -1,6 +1,7 @@
 import { Box, Grid, Typography } from '@mui/material';
 import { format } from 'date-fns';
 import prettyBytes from 'pretty-bytes';
+import { get } from 'lodash';
 
 import Other from '../../assets/icons/Other.svg';
 import Word from '../../assets/icons/Word.svg';
@@ -29,6 +30,8 @@ const NodeTypes = {
 export const NodeItem = ({ node, row }: any) => {
   const { entry } = node;
   const { name, modifiedAt, content } = entry;
+  const contentMimeType = get(content, 'mimeType', '');
+  const contentSizeInBytes = get(content, 'sizeInBytes', 0);
 
   const matchMimeType = (mimeType: string) => {
     const foundMimeType = Object.entries(NodeTypes).find(([key]) => mimeType.indexOf(key) !== -1);
@@ -42,11 +45,7 @@ export const NodeItem = ({ node, row }: any) => {
       sx={{ paddingBottom: '18px', backgroundColor: row % 2 ? Colors.lightgrey : Colors.white }}
     >
       <Grid item mobile={1} tablet={0.5} desktop={0.5}>
-        <Box
-          component="img"
-          src={content && content.mimeType ? matchMimeType(content.mimeType) : NodeTypes.other}
-          alt="Logo"
-        />
+        <Box component="img" src={matchMimeType(contentMimeType)} alt="Logo" />
       </Grid>
       <Grid item mobile={11} tablet={11.5} desktop={11.5}>
         <Typography variant="body1">{name}</Typography>
@@ -55,7 +54,7 @@ export const NodeItem = ({ node, row }: any) => {
             {format(new Date(modifiedAt), DateFormat)}
           </Typography>
           <Typography variant="body1" sx={{ marginRight: '8px' }}>
-            {getLocaleByteUnit(prettyBytes(content.sizeInBytes || 0, { locale: 'fi' }), LocaleLang.FI)}
+            {getLocaleByteUnit(prettyBytes(contentSizeInBytes, { locale: 'fi' }), LocaleLang.FI)}
           </Typography>
         </div>
       </Grid>

--- a/packages/frontend/src/pages/Search/SearchResult.tsx
+++ b/packages/frontend/src/pages/Search/SearchResult.tsx
@@ -10,6 +10,7 @@ import { useContext } from 'react';
 import { SearchContext } from '../../contexts/SearchContext';
 import { formatYear } from '../../utils/helpers';
 import { useSearchParams } from 'react-router-dom';
+import { mimeNamesMapping } from '../../constants/Data';
 
 export const SearchResult = () => {
   const { t } = useTranslation(['search', 'common']);
@@ -21,7 +22,7 @@ export const SearchResult = () => {
     term: query,
     from: formatYear(years[0]),
     to: formatYear(years[1]),
-    fileTypes: checkedList.mime,
+    fileTypes: checkedList.mime.map((mimeType: string) => mimeNamesMapping[mimeType as keyof typeof mimeNamesMapping]),
   };
 
   const { isLoading, isError, error, data } = usePostAlfrescoSearch(searchParameter);


### PR DESCRIPTION
- "Something went wrong" still exists. Turns out there's no null check for `content.sizeInBytes`
- Map mimetype before sending api request