### PR TITLE
Fix router wildcard path

### DIFF
--- a/packages/frontend/src/constants/Routes.ts
+++ b/packages/frontend/src/constants/Routes.ts
@@ -5,5 +5,5 @@ export const Routes = {
   LANDING: '/etusivu',
   SEARCH_RESULT: '/haku',
   LOGOUT: 'logout',
-  LOGOUT_REDIRECT: '/sso/logout*',
+  LOGOUT_REDIRECT: '/sso/*',
 };


### PR DESCRIPTION
'wildcard character must always follow a `/`'
- reduce path to sso/*