### PR TITLE
update local database usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,13 @@ compose database
 docker-compose up
 ```
 
-Copy this variable in your packages/server/.env file
+copy ´DATABASE_URL´ variable from ´/packages/server/.env.example´ to ´/packages/server/.env´
 
 ```
 DATABASE_URL="postgresql://root:root@docker.internal:5432/test_db?schema=public"
 ```
+
+> Here we use ´docker.internal´ as database IP. If you want to configure postgres parameters (e.g. port number) you can do it in ´docker.compose.yml´.
 
 run migration
 

--- a/README.md
+++ b/README.md
@@ -176,16 +176,10 @@ compose database
 docker-compose up
 ```
 
-Get your IP address
+Copy this variable in your packages/server/.env file
 
 ```
-ipconfig getifaddr en0
-```
-
-Copy address to packages/server/.env file
-
-```
-DATABASE_URL="postgresql://root:root@<IP_ADDRESS>:5432/test_db?schema=public"
+DATABASE_URL="postgresql://root:root@docker.internal:5432/test_db?schema=public"
 ```
 
 run migration

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -7,4 +7,4 @@ DB_PORT=5432
 DATABASE_NAME=test_db
 DATABASE_USER=root
 PGPASSWORD=root
-DATABASE_URL="postgresql://root:root@123.123.0.0:5432/test_db?schema=public"
+DATABASE_URL="postgresql://root:root@docker.internal:5432/test_db?schema=public"


### PR DESCRIPTION
Makes using local database easier by using ´docker.internal´ instead of host machine IP-address