### PR TITLE
Feat/RTENU-129 search history clickable links

### DIFF
--- a/packages/frontend/src/assets/locales/fi/search.json
+++ b/packages/frontend/src/assets/locales/fi/search.json
@@ -3,6 +3,7 @@
   "to_year": "Vuotee",
   "search_results": "Hakutulokset",
   "results": "tulosta",
+  "last_searches": "VIIMEISET HAUT",
   "action": {
     "update_results": "Päivitä tulokset",
     "remove_filters": "Poista kaikki suodattimet"

--- a/packages/frontend/src/components/Search/RecentSearch.tsx
+++ b/packages/frontend/src/components/Search/RecentSearch.tsx
@@ -8,7 +8,11 @@ import { Routes } from '../../constants/Routes';
 import { appbarWidth } from '../../constants/Viewports';
 import { KeyEnum, LocalStorageHelper } from '../../utils/StorageHelper';
 
-export const RecentSearch = () => {
+type RecentSearchProps = {
+  exitSearch: () => void;
+};
+
+export const RecentSearch = ({ exitSearch }: RecentSearchProps) => {
   const { t } = useTranslation(['search']);
 
   const RecentSearchItems = () => {
@@ -17,7 +21,9 @@ export const RecentSearch = () => {
       items &&
       items.map((searchText: string, index: number) => (
         <Typography key={index} variant="body1">
-          <CustomLink to={`${Routes.SEARCH_RESULT}?query=${searchText}`}>{searchText}</CustomLink>
+          <CustomLink to={`${Routes.SEARCH_RESULT}?query=${searchText}`} onClick={exitSearch}>
+            {searchText}
+          </CustomLink>
         </Typography>
       ))
     );

--- a/packages/frontend/src/components/Search/RecentSearch.tsx
+++ b/packages/frontend/src/components/Search/RecentSearch.tsx
@@ -2,11 +2,12 @@ import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { SearchStorage } from '.';
 
 import { Colors } from '../../constants/Colors';
 import { Routes } from '../../constants/Routes';
 import { appbarWidth } from '../../constants/Viewports';
-import { KeyEnum, LocalStorageHelper } from '../../utils/StorageHelper';
+import { KeyEnum } from '../../utils/StorageHelper';
 
 type RecentSearchProps = {
   exitSearch: () => void;
@@ -16,12 +17,18 @@ export const RecentSearch = ({ exitSearch }: RecentSearchProps) => {
   const { t } = useTranslation(['search']);
 
   const RecentSearchItems = () => {
-    const items = new LocalStorageHelper().get(KeyEnum.RECENT_SEARCHES);
+    const items = SearchStorage.get(KeyEnum.RECENT_SEARCHES);
     return (
       items &&
       items.map((searchText: string, index: number) => (
         <Typography key={index} variant="body1">
-          <CustomLink to={`${Routes.SEARCH_RESULT}?query=${searchText}`} onClick={exitSearch}>
+          <CustomLink
+            to={`${Routes.SEARCH_RESULT}?query=${searchText}`}
+            onClick={() => {
+              SearchStorage.add(KeyEnum.RECENT_SEARCHES, searchText);
+              exitSearch();
+            }}
+          >
             {searchText}
           </CustomLink>
         </Typography>

--- a/packages/frontend/src/components/Search/RecentSearch.tsx
+++ b/packages/frontend/src/components/Search/RecentSearch.tsx
@@ -1,17 +1,23 @@
 import styled from '@emotion/styled';
 import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
 import { Colors } from '../../constants/Colors';
+import { Routes } from '../../constants/Routes';
 import { appbarWidth } from '../../constants/Viewports';
 import { KeyEnum, LocalStorageHelper } from '../../utils/StorageHelper';
 
 export const RecentSearch = () => {
+  const { t } = useTranslation(['search']);
+
   const RecentSearchItems = () => {
     const items = new LocalStorageHelper().get(KeyEnum.RECENT_SEARCHES);
     return (
       items &&
       items.map((searchText: string, index: number) => (
         <Typography key={index} variant="body1">
-          {searchText}
+          <CustomLink to={`${Routes.SEARCH_RESULT}?query=${searchText}`}>{searchText}</CustomLink>
         </Typography>
       ))
     );
@@ -20,7 +26,7 @@ export const RecentSearch = () => {
   return (
     <RecentSearchWrapper>
       <Typography variant="body1" sx={{ color: Colors.darkgrey }}>
-        VIIMEISET HAUT
+        {t('search:last_searches')}
       </Typography>
       <RecentSearchItems />
     </RecentSearchWrapper>
@@ -47,3 +53,11 @@ const RecentSearchWrapper = styled('div')(({ theme }) => {
     },
   };
 });
+
+const CustomLink = styled(Link)(() => ({
+  textDecoration: 'none',
+  color: Colors.extrablack,
+  '&:hover': {
+    color: Colors.darkblue,
+  },
+}));

--- a/packages/frontend/src/components/Search/index.tsx
+++ b/packages/frontend/src/components/Search/index.tsx
@@ -92,7 +92,7 @@ export const Search = ({ openSearch, toggleSearch, openFilter, toggleFilter, isD
           {openFilter ? <DisabledByDefaultIcon color="primary" /> : <TuneIcon color="primary" />}
         </IconButton>
       </>
-      {openSearch && !openFilter && <RecentSearch />}
+      {openSearch && !openFilter && <RecentSearch exitSearch={exitSearch} />}
       <FilterSearch openFilter={openFilter} toggleFilter={toggleFilter} />
     </>
   );

--- a/packages/frontend/src/components/Search/index.tsx
+++ b/packages/frontend/src/components/Search/index.tsx
@@ -21,13 +21,13 @@ type SearchProps = {
   isDesktop?: boolean;
 };
 
+// Set limit for number of searches
+export const SearchStorage = new LocalStorageHelper(5);
+
 export const Search = ({ openSearch, toggleSearch, openFilter, toggleFilter, isDesktop = false }: SearchProps) => {
   const searchContext = useContext(SearchContext);
   const { query, queryHandler } = searchContext;
   const navigate = useNavigate();
-
-  // Set limit for number of searches
-  const SearchStorage = new LocalStorageHelper(5);
 
   const closeSearch = () => {
     openSearch && toggleSearch();
@@ -60,7 +60,14 @@ export const Search = ({ openSearch, toggleSearch, openFilter, toggleFilter, isD
 
   const MiniLeftSearchBar = () => {
     return openSearch ? (
-      <IconButton size="large" edge="start" area-label="back" onClick={exitSearch}>
+      <IconButton
+        size="large"
+        edge="start"
+        area-label="back"
+        onClick={() => {
+          exitSearch();
+        }}
+      >
         <ArrayBackIcon color="primary" />
       </IconButton>
     ) : (

--- a/packages/frontend/src/pages/Search/SearchResult.tsx
+++ b/packages/frontend/src/pages/Search/SearchResult.tsx
@@ -39,6 +39,9 @@ export const SearchResult = () => {
   if (isError) {
     return (
       <ContainerWrapper>
+        <Typography variant="subtitle1">
+          {t('search:search_results')} "{query}"
+        </Typography>
         <Alert severity="error">{error?.message || t('common:error.500')}</Alert>
       </ContainerWrapper>
     );

--- a/packages/frontend/src/utils/StorageHelper.ts
+++ b/packages/frontend/src/utils/StorageHelper.ts
@@ -16,7 +16,9 @@ export class LocalStorageHelper {
     if (this.localStorageSupported && value) {
       const item = this.get(key);
       if (this.maxLen) {
-        const arr = Array.isArray(item) ? [value, ...item] : [item];
+        const arr = Array.isArray(item)
+          ? [value, ...item.filter((val: string) => val.toLowerCase() !== value.toLowerCase())]
+          : [value];
         if (this.maxLen < arr.length) {
           arr.pop();
         }

--- a/packages/frontend/src/utils/__tests__/StorageHelper.test.ts
+++ b/packages/frontend/src/utils/__tests__/StorageHelper.test.ts
@@ -38,6 +38,16 @@ describe('StorageHelper', () => {
     myStorage.add(KeyEnum.RECENT_SEARCHES, 'C');
     expect(myStorage.get(KeyEnum.RECENT_SEARCHES)).toEqual(['C', 'B']);
   });
+
+  it('should replace duplicated value (insensitive case)', () => {
+    const myStorage = new LocalStorageHelper(3);
+    myStorage.add(KeyEnum.RECENT_SEARCHES, 'A');
+    myStorage.add(KeyEnum.RECENT_SEARCHES, 'B');
+    myStorage.add(KeyEnum.RECENT_SEARCHES, '');
+    myStorage.add(KeyEnum.RECENT_SEARCHES, 'C');
+    myStorage.add(KeyEnum.RECENT_SEARCHES, 'b');
+    expect(myStorage.get(KeyEnum.RECENT_SEARCHES)).toEqual(['b', 'C', 'A']);
+  });
 });
 // Or can set `"isolatedModules": false` in tsconfig.json
 export {};


### PR DESCRIPTION
<img width="287" alt="Screenshot 2022-12-28 at 13 49 33" src="https://user-images.githubusercontent.com/31354481/209807664-1108d861-0fb7-4b80-949a-92591c979340.png">

**Done**
- Improve LocalStorageHelper class functionality: remove duplicates, fix `null` bug (first time search adds null to array)
- Recent search is clickable, add clicked term to local storage