### PR TITLE
fix file upload form

### DIFF
--- a/packages/frontend/src/components/Files/FileUploadDialog.tsx
+++ b/packages/frontend/src/components/Files/FileUploadDialog.tsx
@@ -58,6 +58,7 @@ export const FileUploadDialog = ({ categoryName }: FileUploadProps) => {
     const { files } = event.target;
     const selectedFiles = files as FileList;
     setFile(selectedFiles?.[0]);
+    setName(selectedFiles?.[0].name);
   };
 
   switch (dialogPhase) {

--- a/packages/frontend/src/services/FileUploadService.ts
+++ b/packages/frontend/src/services/FileUploadService.ts
@@ -16,7 +16,10 @@ export const uploadFile = async (file: File, fileData: FileData): Promise<AxiosR
     form.append('nodeType', 'cm:content');
     const options = {
       method: 'POST',
-      body: form,
+      data: form,
+      headers: {
+        'content-type': 'multipart/form-data',
+      },
     };
     response = await axios(`/api/alfresco/file/${parentNode}`, options);
   }


### PR DESCRIPTION
Small fixes to file upload form.

- Set name as part of request when selecting file
- Change axios request parameter from 'body' to 'data'
- Set content-type header