### PR TITLE
Feat/126-update-file-metadata

### DIFF
--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -237,6 +237,12 @@ export class RataExtraBackendStack extends NestedStack {
       relativePath: '../packages/server/lambdas/alfresco/upload-file.ts',
     });
 
+    const alfrescoUpdateFile = this.createNodejsLambda({
+      ...prismaAlfrescoCombinedParameters,
+      name: 'alfresco-update-file',
+      relativePath: '../packages/server/lambdas/alfresco/update-file.ts',
+    });
+
     const dbGetPageContents = this.createNodejsLambda({
       ...prismaParameters,
       name: 'db-get-page-contents',
@@ -289,6 +295,13 @@ export class RataExtraBackendStack extends NestedStack {
         path: ['/api/alfresco/file/*'],
         httpRequestMethods: ['POST'],
         targetName: 'alfrescoUploadFile',
+      },
+      {
+        lambda: alfrescoUpdateFile,
+        priority: 130,
+        path: ['/api/alfresco/file/*'],
+        httpRequestMethods: ['PUT'],
+        targetName: 'alfrescoUpdateFile',
       },
       {
         lambda: dbGetPageContents,

--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -305,7 +305,7 @@ export class RataExtraBackendStack extends NestedStack {
       {
         lambda: alfrescoUpdateFile,
         priority: 130,
-        path: ['/api/alfresco/file/*'],
+        path: ['/api/alfresco/file/*/content'],
         httpRequestMethods: ['PUT'],
         targetName: 'alfrescoUpdateFile',
       },

--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -243,6 +243,12 @@ export class RataExtraBackendStack extends NestedStack {
       relativePath: '../packages/server/lambdas/alfresco/update-file.ts',
     });
 
+    const alfrescoUpdateFileMetadata = this.createNodejsLambda({
+      ...prismaAlfrescoCombinedParameters,
+      name: 'alfresco-update-file-metadata',
+      relativePath: '../packages/server/lambdas/alfresco/update-file-metadata.ts',
+    });
+
     const dbGetPageContents = this.createNodejsLambda({
       ...prismaParameters,
       name: 'db-get-page-contents',
@@ -302,6 +308,13 @@ export class RataExtraBackendStack extends NestedStack {
         path: ['/api/alfresco/file/*'],
         httpRequestMethods: ['PUT'],
         targetName: 'alfrescoUpdateFile',
+      },
+      {
+        lambda: alfrescoUpdateFileMetadata,
+        priority: 132,
+        path: ['/api/alfresco/file/*'],
+        httpRequestMethods: ['PUT'],
+        targetName: 'alfrescoUpdateFileMetadata',
       },
       {
         lambda: dbGetPageContents,

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -5,8 +5,13 @@ import { ALBEvent } from 'aws-lambda';
 import { Blob } from 'buffer';
 import { FileInfo } from 'busboy';
 
-const base64ToBuffer = (base64string: string) => {
+const base64ToString = (base64string: string): string => {
   const buffer = Buffer.from(base64string, 'base64').toString('utf-8').replace(/\r?\n/g, '\r\n');
+  return buffer;
+};
+
+const base64ToBuffer = (base64string: string): Buffer => {
+  const buffer = Buffer.from(base64string, 'base64');
   return buffer;
 };
 
@@ -27,7 +32,7 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
 
 export class AlfrescoFileRequestBuilder {
   public async requestBuilder(event: ALBEvent, headers: HeadersInit) {
-    event.body = base64ToBuffer(event.body as string);
+    event.body = base64ToString(event.body as string);
     const parsedForm = (await parseForm(event)) as ParsedFormDataOptions;
     const options = {
       method: 'POST',
@@ -37,11 +42,10 @@ export class AlfrescoFileRequestBuilder {
     return options;
   }
   public async updateRequestBuilder(event: ALBEvent, headers: HeadersInit) {
-    event.body = base64ToBuffer(event.body as string);
-    const fileData = (await parseForm(event)) as ParsedFormDataOptions;
+    const buffer = base64ToBuffer(event.body as string);
     const options = {
       method: 'PUT',
-      body: fileData.file,
+      body: buffer,
       headers: headers,
     } as unknown as RequestInit;
     return options;

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -36,6 +36,16 @@ export class AlfrescoFileRequestBuilder {
     } as unknown as RequestInit;
     return options;
   }
+  public async updateRequestBuilder(event: ALBEvent, headers: HeadersInit) {
+    event.body = base64ToBuffer(event.body as string);
+    const fileData = (await parseForm(event)) as ParsedFormDataOptions;
+    const options = {
+      method: 'PUT',
+      body: fileData.file,
+      headers: headers,
+    } as unknown as RequestInit;
+    return options;
+  }
   public deleteRequestBuilder(requestParameters: FileDeleteRequestBody): FileDeleteRequest {
     throw new Error('Method not implemented.');
   }

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -38,7 +38,7 @@ export class AlfrescoFileRequestBuilder {
       method: 'POST',
       body: createForm(parsedForm),
       headers: headers,
-    } as unknown as RequestInit;
+    } as RequestInit;
     return options;
   }
   public async updateRequestBuilder(event: ALBEvent, headers: HeadersInit) {
@@ -47,7 +47,15 @@ export class AlfrescoFileRequestBuilder {
       method: 'PUT',
       body: buffer,
       headers: headers,
-    } as unknown as RequestInit;
+    } as RequestInit;
+    return options;
+  }
+  public async updateJsonRequestBuilder(event: ALBEvent, headers: HeadersInit) {
+    const options = {
+      method: 'PUT',
+      body: event.body,
+      headers: headers,
+    } as RequestInit;
     return options;
   }
   public deleteRequestBuilder(requestParameters: FileDeleteRequestBody): FileDeleteRequest {

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/index.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/index.ts
@@ -18,6 +18,14 @@ export const updateFileRequestBuilder = (event: ALBEvent, headers: HeadersInit, 
       return alfrescoRequestBuilder.updateRequestBuilder(event, headers);
   }
 };
+export const updateFileMetadataRequestBuilder = (event: ALBEvent, headers: HeadersInit, store?: FileStore) => {
+  switch (store) {
+    case FileStore.ALFRESCO:
+    default:
+      const alfrescoRequestBuilder = new AlfrescoFileRequestBuilder();
+      return alfrescoRequestBuilder.updateJsonRequestBuilder(event, headers);
+  }
+};
 export const deleteFileRequestBuilder = (request: FileDeleteRequestBody, store?: FileStore): FileDeleteRequest => {
   switch (store) {
     case FileStore.ALFRESCO:

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/index.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/index.ts
@@ -10,6 +10,14 @@ export const fileRequestBuilder = (event: ALBEvent, headers: HeadersInit, store?
       return alfrescoRequestBuilder.requestBuilder(event, headers);
   }
 };
+export const updateFileRequestBuilder = (event: ALBEvent, headers: HeadersInit, store?: FileStore) => {
+  switch (store) {
+    case FileStore.ALFRESCO:
+    default:
+      const alfrescoRequestBuilder = new AlfrescoFileRequestBuilder();
+      return alfrescoRequestBuilder.updateRequestBuilder(event, headers);
+  }
+};
 export const deleteFileRequestBuilder = (request: FileDeleteRequestBody, store?: FileStore): FileDeleteRequest => {
   switch (store) {
     case FileStore.ALFRESCO:

--- a/packages/server/lambdas/alfresco/update-file-metadata.ts
+++ b/packages/server/lambdas/alfresco/update-file-metadata.ts
@@ -1,0 +1,82 @@
+import { CategoryDataBase } from '@prisma/client';
+import { ALBEvent, ALBResult } from 'aws-lambda';
+import { isEmpty } from 'lodash';
+import { findEndpoint, getAlfrescoOptions, getAlfrescoUrlBase } from '../../utils/alfresco';
+import { getRataExtraLambdaError, RataExtraLambdaError } from '../../utils/errors';
+import { log } from '../../utils/logger';
+import { getUser, validateReadUser, validateWriteUser } from '../../utils/userService';
+import { DatabaseClient } from '../database/client';
+import { updateFileMetadataRequestBuilder } from './fileRequestBuilder';
+import fetch from 'node-fetch';
+import { RequestInit } from 'node-fetch';
+import { AlfrescoResponse } from './fileRequestBuilder/types';
+
+const database = await DatabaseClient.build();
+
+let fileEndpointsCache: Array<CategoryDataBase> = [];
+
+const updateFileMetadata = async (options: RequestInit, nodeId: string): Promise<AlfrescoResponse | undefined> => {
+  const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
+  const url = `${alfrescoCoreAPIUrl}/nodes/${nodeId}`;
+
+  try {
+    const res = await fetch(url, options);
+    const result = (await res.json()) as AlfrescoResponse;
+    return result;
+  } catch (err) {
+    console.error('error:' + err);
+  }
+};
+
+/**
+ * Upload custom content for page. Example request: /api/alfresco/file/linjakaaviot
+ * @param {ALBEvent} event
+ * @param {{string}} event.path Path should end with the page to upload the file to
+ * @param {{string}} event.body File contents and metadata to upload
+ * @returns  {Promise<ALBResult>} JSON stringified object of uploaded file metadata
+ */
+export async function handleRequest(event: ALBEvent): Promise<ALBResult | undefined> {
+  try {
+    const paths = event.path.split('/');
+    const nodeId = paths.at(-1);
+    const category = paths.at(-2);
+
+    const user = await getUser(event);
+    log.info(user, `Updating file ${nodeId} in ${category}`);
+    validateReadUser(user);
+
+    if (!category) {
+      throw new RataExtraLambdaError('Category missing from path', 400);
+    }
+    if (!nodeId) {
+      throw new RataExtraLambdaError('Node ID missing from path', 400);
+    }
+    if (isEmpty(event.body)) {
+      throw new RataExtraLambdaError('Request body missing', 400);
+    }
+    if (!fileEndpointsCache.length) {
+      fileEndpointsCache = await database.categoryDataBase.findMany();
+    }
+    const categoryData = findEndpoint(category, fileEndpointsCache);
+    if (!categoryData) {
+      throw new RataExtraLambdaError('Category not found', 404);
+    }
+
+    const writeRole = categoryData.writeRights;
+    validateWriteUser(user, writeRole);
+
+    const headers = (await getAlfrescoOptions(user.uid)).headers;
+    const requestOptions = (await updateFileMetadataRequestBuilder(event, headers)) as RequestInit;
+
+    const result = await updateFileMetadata(requestOptions, nodeId);
+    log.info(user, `Updated file ${nodeId} in ${categoryData.alfrescoFolder}`);
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type:': 'application/json' },
+      body: JSON.stringify(result),
+    };
+  } catch (err) {
+    log.error(err);
+    return getRataExtraLambdaError(err);
+  }
+}

--- a/packages/server/lambdas/alfresco/update-file-metadata.ts
+++ b/packages/server/lambdas/alfresco/update-file-metadata.ts
@@ -29,7 +29,7 @@ const updateFileMetadata = async (options: RequestInit, nodeId: string): Promise
 };
 
 /**
- * Upload custom content for page. Example request: /api/alfresco/file/linjakaaviot
+ * Update file metadata. Example request: /api/alfresco/file/linjakaaviot/AAA-123-BBB
  * @param {ALBEvent} event
  * @param {{string}} event.path Path should end with the page to upload the file to
  * @param {{string}} event.body File contents and metadata to upload

--- a/packages/server/lambdas/alfresco/update-file.ts
+++ b/packages/server/lambdas/alfresco/update-file.ts
@@ -44,8 +44,8 @@ const updateFile = async (
 export async function handleRequest(event: ALBEvent): Promise<ALBResult | undefined> {
   try {
     const paths = event.path.split('/');
-    const nodeId = paths.at(-1);
-    const category = paths.at(-2);
+    const nodeId = paths.at(-2);
+    const category = paths.at(-3);
     const name = event.queryStringParameters?.name;
 
     const user = await getUser(event);

--- a/packages/server/lambdas/alfresco/update-file.ts
+++ b/packages/server/lambdas/alfresco/update-file.ts
@@ -35,7 +35,7 @@ const postFile = async (options: RequestInit, nodeId: string): Promise<AlfrescoR
  * @returns  {Promise<ALBResult>} JSON stringified object of uploaded file metadata
  */
 export async function handleRequest(event: ALBEvent): Promise<ALBResult | undefined> {
-  console.log('Event: ', event);
+  console.log('EVENT: ', event);
   try {
     const paths = event.path.split('/');
     const category = paths.pop();

--- a/packages/server/lambdas/alfresco/update-file.ts
+++ b/packages/server/lambdas/alfresco/update-file.ts
@@ -1,0 +1,78 @@
+import { CategoryDataBase } from '@prisma/client';
+import { ALBEvent, ALBResult } from 'aws-lambda';
+import { isEmpty } from 'lodash';
+import { findEndpoint, getAlfrescoOptions, getAlfrescoUrlBase } from '../../utils/alfresco';
+import { getRataExtraLambdaError, RataExtraLambdaError } from '../../utils/errors';
+import { log } from '../../utils/logger';
+import { getUser, validateReadUser, validateWriteUser } from '../../utils/userService';
+import { DatabaseClient } from '../database/client';
+import { fileRequestBuilder } from './fileRequestBuilder';
+import fetch from 'node-fetch';
+import { RequestInit } from 'node-fetch';
+import { AlfrescoResponse } from './fileRequestBuilder/types';
+
+const database = await DatabaseClient.build();
+
+let fileEndpointsCache: Array<CategoryDataBase> = [];
+
+const postFile = async (options: RequestInit, nodeId: string): Promise<AlfrescoResponse | undefined> => {
+  const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
+  const url = `${alfrescoCoreAPIUrl}/nodes/${nodeId}/children`;
+  try {
+    const res = await fetch(url, options);
+    const result = (await res.json()) as AlfrescoResponse;
+    return result;
+  } catch (err) {
+    console.error('error:' + err);
+  }
+};
+
+/**
+ * Upload custom content for page. Example request: /api/alfresco/file/linjakaaviot
+ * @param {ALBEvent} event
+ * @param {{string}} event.path Path should end with the page to upload the file to
+ * @param {{string}} event.body File contents and metadata to upload
+ * @returns  {Promise<ALBResult>} JSON stringified object of uploaded file metadata
+ */
+export async function handleRequest(event: ALBEvent): Promise<ALBResult | undefined> {
+  console.log('Event: ', event);
+  try {
+    const paths = event.path.split('/');
+    const category = paths.pop();
+
+    const user = await getUser(event);
+    log.info(user, `Uploading files for page ${category}`);
+    validateReadUser(user);
+
+    if (!category || paths.pop() !== 'file') {
+      throw new RataExtraLambdaError('Category missing from path', 400);
+    }
+    if (isEmpty(event.body)) {
+      throw new RataExtraLambdaError('Request body missing', 400);
+    }
+    if (!fileEndpointsCache.length) {
+      fileEndpointsCache = await database.categoryDataBase.findMany();
+    }
+    const categoryData = findEndpoint(category, fileEndpointsCache);
+    if (!categoryData) {
+      throw new RataExtraLambdaError('Category not found', 404);
+    }
+
+    const writeRole = categoryData.writeRights;
+    validateWriteUser(user, writeRole);
+
+    const headers = (await getAlfrescoOptions(user.uid)).headers;
+    const requestOptions = (await fileRequestBuilder(event, headers)) as RequestInit;
+
+    const result = await postFile(requestOptions, categoryData.alfrescoFolder);
+    log.info(user, `Uploaded file ${result?.entry.name} to ${categoryData.alfrescoFolder}`);
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type:': 'application/json' },
+      body: JSON.stringify(result),
+    };
+  } catch (err) {
+    log.error(err);
+    return getRataExtraLambdaError(err);
+  }
+}

--- a/packages/server/lambdas/alfresco/update-file.ts
+++ b/packages/server/lambdas/alfresco/update-file.ts
@@ -35,7 +35,7 @@ const updateFile = async (
 };
 
 /**
- * Update file content. Example request: /api/alfresco/file/linjakaaviot
+ * Update file content. Example request: /api/alfresco/file/linjakaaviot/FOO-123-AAA/content
  * @param {ALBEvent} event
  * @param {{string}} event.path Path should end with the page to upload the file to
  * @param {{string}} event.body File contents and metadata to upload


### PR DESCRIPTION
🔔 This PR is pointing to #163 !

- Add update-metadata endpoint and lambda.

- Edit update-file endpoint -> use `../{nodeId}/content` path parameter for content update and `../{nodeId}/` for updating metadata.