### PR TITLE
Feat/127 file tests

### DIFF
--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -2,6 +2,7 @@
 const config = {
   verbose: true,
   transformIgnorePatterns: ['node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)'],
+  testPathIgnorePatterns: ['/node_modules/', '__mocks__'],
 };
 
 export default config;

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/__tests__/__mocks__/mockFormOptions.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/__tests__/__mocks__/mockFormOptions.ts
@@ -1,0 +1,14 @@
+import { ParsedFormDataOptions } from '../../../../../utils/parser';
+
+const buffer = Buffer.alloc(5);
+
+const parsedFormData: ParsedFormDataOptions = {
+  filedata: buffer,
+  fileinfo: {
+    filename: 'file.pdf',
+    encoding: 'utf8',
+    mimeType: 'application/pdf',
+  },
+};
+
+export const mockFormDataOptions = JSON.stringify(parsedFormData);

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/__tests__/index.test.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/__tests__/index.test.ts
@@ -1,34 +1,102 @@
-import { fileRequestBuilder } from '../../fileRequestBuilder';
+import {
+  fileRequestBuilder,
+  updateFileRequestBuilder,
+  updateFileMetadataRequestBuilder,
+  deleteFileRequestBuilder,
+} from '../../fileRequestBuilder';
+import { mockFormDataOptions } from './__mocks__/mockFormOptions';
+
+type jsonBody = {
+  name: string;
+};
+
+const options = {
+  requestContext: {
+    elb: {
+      targetGroupArn: '',
+    },
+  },
+  httpMethod: '',
+  path: '',
+  body: '' as any,
+  isBase64Encoded: true,
+  headers: {
+    accept: 'application/json',
+    'content-type': '',
+  },
+};
 
 describe('fileRequestBuilder', () => {
-  it('returns body based on given values', async () => {
-    const requestOptions = await fileRequestBuilder(
-      {
-        requestContext: {
-          elb: {
-            targetGroupArn: '',
-          },
-        },
-        httpMethod: 'POST',
-        path: '/api/alfresco/file/hallintaraportit',
-        body: 'BASE64STRING==',
-        isBase64Encoded: true,
-        headers: {
-          accept: 'multipart/form-data',
-        },
-      },
-      {
-        'X-API-Key': '',
-        'OAM-REMOTE-USER': '',
-      },
-    );
+  it('returns file-upload body based on given values', async () => {
+    options.httpMethod = 'POST';
+    options.path = '/api/alfresco/file/hallintaraportit';
+    options.headers['content-type'] = 'multipart/form-data';
+    options.isBase64Encoded = false;
+    options.body = mockFormDataOptions;
 
+    const requestOptions = await fileRequestBuilder(options, {
+      'X-API-Key': '',
+      'OAM-REMOTE-USER': '',
+    });
     type Options = {
       method: string;
       body?: FormData | any;
       headers?: { 'X-API-Key': string; 'OAM-REMOTE-USER': string };
     };
 
-    expect(requestOptions).toMatchObject<Options>({ method: 'POST' });
+    expect(requestOptions).toMatchObject<Options>({ method: options.httpMethod });
+  });
+  it('returns update-file body based on given values', async () => {
+    options.httpMethod = 'PUT';
+    options.path = '/api/alfresco/file/hallintaraportit/foo-123/content';
+    options.body = 'BASE64STRING==';
+
+    const requestOptions = await updateFileRequestBuilder(options, {
+      'X-API-Key': '',
+      'OAM-REMOTE-USER': '',
+    });
+    type Options = {
+      method: string;
+      body?: Buffer;
+      headers?: { 'X-API-Key': string; 'OAM-REMOTE-USER': string };
+    };
+
+    expect(requestOptions).toMatchObject<Options>({ method: options.httpMethod });
+  });
+  it('returns update-file-content body based on given values', () => {
+    options.httpMethod = 'PUT';
+    options.path = '/api/alfresco/file/hallintaraportit/foo-123';
+    options.body = { name: 'file_v2.1.txt' };
+
+    const requestOptions = updateFileMetadataRequestBuilder(options, {
+      'X-API-Key': '',
+      'OAM-REMOTE-USER': '',
+    });
+
+    type Options = {
+      method: string;
+      body?: jsonBody;
+      headers?: { 'X-API-Key': string; 'OAM-REMOTE-USER': string };
+    };
+
+    expect(requestOptions).toMatchObject<Options>({ method: options.httpMethod });
+  });
+  it('returns delete-request body based on given values', () => {
+    options.httpMethod = 'DELETE';
+    options.path = '/api/alfresco/file/hallintaraportit/foo-123';
+    options.body = null;
+
+    const requestOptions = deleteFileRequestBuilder({
+      'X-API-Key': '',
+      'OAM-REMOTE-USER': '',
+    });
+
+    type Options = {
+      method: string;
+      body?: null;
+      headers?: { 'X-API-Key': string; 'OAM-REMOTE-USER': string };
+    };
+
+    expect(requestOptions).toMatchObject<Options>({ method: options.httpMethod });
   });
 });

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -31,11 +31,14 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
 
 export class AlfrescoFileRequestBuilder {
   public async requestBuilder(event: ALBEvent, headers: HeadersInit) {
-    event.body = base64ToString(event.body as string);
-    const parsedForm = (await parseForm(event)) as ParsedFormDataOptions;
+    let parsedFormData = JSON.parse(event.body as string);
+    if (event.isBase64Encoded) {
+      event.body = base64ToString(event.body as string);
+      parsedFormData = (await parseForm(event)) as ParsedFormDataOptions;
+    }
     const options = {
       method: 'POST',
-      body: createForm(parsedForm),
+      body: createForm(parsedFormData),
       headers: headers,
     } as RequestInit;
     return options;


### PR DESCRIPTION
Unit tests for file api requests

- Add unit tests and mock data
- Add [testPathIgnorePatterns](https://jestjs.io/docs/configuration#testpathignorepatterns-arraystring) option to jest config. Ignores __mocks__ path.
- Allow passing non-base64 encoded value as requestBuilder parameter.
  - This skips busboy parse step thus separating function from ALBEvent.