### PR TITLE
Feat/RTENU-156 extended search

### DIFF
--- a/packages/frontend/src/assets/locales/fi/search.json
+++ b/packages/frontend/src/assets/locales/fi/search.json
@@ -6,7 +6,7 @@
   "time": "Aika",
   "sort_results": "Lajittele tulokset",
   "content_search": "Sisältöhaku",
-  "content_search_checkbox": "Etsi tiedoston sisällöstä",
+  "content_search_checkbox": "Hae pelkästään sisällöstä",
   "no_sort": "Ei lajiteltu",
   "A-Z": "A-Ö",
   "Z-A": "Ö-A",

--- a/packages/server/lambdas/alfresco/searchQueryBuilder/__tests__/luceneQueryBuilder.test.ts
+++ b/packages/server/lambdas/alfresco/searchQueryBuilder/__tests__/luceneQueryBuilder.test.ts
@@ -117,14 +117,14 @@ describe('Lucene Query Builder', () => {
         '+@cm\\:modified:[2020-01-01 TO 2021-12-31]+@cm\\:content.mimetype:"application/pdf"',
       );
     });
-    it('should return query for name', () => {
+    it('should return extended query (basic search query + content search query) as default', () => {
       const parameters: Array<SearchParameter> = [
         {
           parameterName: SearchParameterName.NAME,
           term: 'test',
         },
       ];
-      expect(luceneQueryBuilder.queryBuilder(parameters)).toEqual('+@cm\\:name:"test*"');
+      expect(luceneQueryBuilder.queryBuilder(parameters)).toEqual('+(TEXT:"test*" @cm\\:name:"test*")');
     });
     it('should return query for content search', () => {
       const parameters: Array<SearchParameter> = [

--- a/packages/server/lambdas/alfresco/searchQueryBuilder/luceneQueryBuilder.ts
+++ b/packages/server/lambdas/alfresco/searchQueryBuilder/luceneQueryBuilder.ts
@@ -72,9 +72,10 @@ export class LuceneQueryBuilder implements SearchQueryBuilder {
   }
 
   buildNameQuery(parameter: INameSearchParameter): string {
-    return parameter.contentSearch
-      ? `+TEXT:"${parameter.term}*"`
-      : `${METADATA_SEARCH_START}name${DIVIDER}"${parameter.term}*"`;
+    const contentSearchQuery = `TEXT:"${parameter.term}*"`;
+    const basicSearchQuery = `@cm\\:name:"${parameter.term}*"`;
+    const extendedSearchQuery = `+(${contentSearchQuery} ${basicSearchQuery})`;
+    return parameter.contentSearch ? `+${contentSearchQuery}` : extendedSearchQuery;
   }
 
   buildParentQuery(parameter: IParentSearchParameter) {


### PR DESCRIPTION
Set extended search as default. `contentSearch = true` will only search content