### PR TITLE
Feat/RTENU-191 toolbar unit test

### DIFF
--- a/cypress/e2e/SlateToolbar-spec.cy.ts
+++ b/cypress/e2e/SlateToolbar-spec.cy.ts
@@ -15,13 +15,13 @@ describe('Slate Toobar', () => {
         it('Home page: view mode', function () {
           cy.viewport(viewport);
           cy.visit('/');
-          cy.get('button[aria-label="open edit"]').should('not.exist');
+          cy.get('button[aria-label="Avaa muokkausnäkymä"]').should('not.exist');
         });
 
         it('Hallintaraportit page: view mode', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('button[aria-label="open edit"]').should('not.exist');
+          cy.get('button[aria-label="Avaa muokkausnäkymä"]').should('not.exist');
         });
       });
 
@@ -35,49 +35,49 @@ describe('Slate Toobar', () => {
         it('Home page: view mode', function () {
           cy.viewport(viewport);
           cy.visit('/');
-          cy.get('[aria-label="open edit"]').should('not.exist');
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').should('not.exist');
         });
 
         it('Hallintaraportit page: write mode', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').should('exist');
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').should('exist');
         });
 
         it('Hallintaraportit page: click on edit mode and toolbar appears', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
-          cy.get('[aria-label="toolbar"]').should('exist');
-          cy.get('[aria-label="paragraph-two"]').should('exist');
-          cy.get('[aria-label="paragraph-one"]').should('exist');
-          cy.get('[aria-label="heading-two"]').should('exist');
-          cy.get('[aria-label="bold"]').should('exist');
-          cy.get('[aria-label="italic"]').should('exist');
-          cy.get('[aria-label="underlined"]').should('exist');
-          cy.get('[aria-label="numbered-list"]').should('exist');
-          cy.get('[aria-label="bulleted-list"]').should('exist');
-          cy.get('[aria-label="insert-link"]').should('exist');
-          cy.get('[aria-label="color"]').should('exist');
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="työkalupalkki"]').should('exist');
+          cy.get('[aria-label="kappale normaalilla tekstikoolla"]').should('exist');
+          cy.get('[aria-label="kappale isommalla tekstikoolla"]').should('exist');
+          cy.get('[aria-label="pienempi otsikko"]').should('exist');
+          cy.get('[aria-label="lihavoitu"]').should('exist');
+          cy.get('[aria-label="kursivoitu"]').should('exist');
+          cy.get('[aria-label="alleviivattu"]').should('exist');
+          cy.get('[aria-label="numeroitu lista"]').should('exist');
+          cy.get('[aria-label="numeroimaton lista"]').should('exist');
+          cy.get('[aria-label="Lisää linkki"]').should('exist');
+          cy.get('[aria-label="väri"]').should('exist');
           cy.get('[aria-label="info"]').should('exist');
-          cy.get('[aria-label="warning"]').should('exist');
-          cy.get('[aria-label="error"]').should('exist');
-          cy.get('[aria-label="check"]').should('exist');
-          cy.get('[aria-label="delete"]').should('exist');
-          cy.get('[aria-label="close"]').should('exist');
+          cy.get('[aria-label="varoitus"]').should('exist');
+          cy.get('[aria-label="virhe"]').should('exist');
+          cy.get('[aria-label="oikein-merkki"]').should('exist');
+          cy.get('[aria-label="Poista"]').should('exist');
+          cy.get('[aria-label="Sulje"]').should('exist');
         });
 
         it('Hallintaraportit page: editor doesnt show up without any notification selection', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').click({ multiple: true, force: true });
           cy.get('[data-testid="slate-editor"] [contenteditable=false]').should('exist');
         });
 
         it('Hallintaraportit page: open info notification and type', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').click({ multiple: true, force: true });
           cy.get('[aria-label="info"]').click();
           const typedText = 'Info texts';
           cy.get('[data-testid="slate-editor"] [contenteditable=true]').type(typedText).contains(typedText);
@@ -86,55 +86,55 @@ describe('Slate Toobar', () => {
         it('Hallintaraportit page: open warning notification and edit text format', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
-          cy.get('[aria-label="warning"]').click();
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="varoitus"]').click();
           const typedText = 'Warning texts';
           cy.get('[data-testid="slate-editor"] [contenteditable=true]')
             .type(typedText)
 
             .type('{selectAll}')
             .contains(typedText);
-          cy.get('[aria-label="bold"]').click();
-          cy.get('[aria-label="italic"]').click();
-          cy.get('[aria-label="heading-one"]').click();
+          cy.get('[aria-label="lihavoitu"]').click();
+          cy.get('[aria-label="kursivoitu"]').click();
+          cy.get('[aria-label="iso otsikko"]').click();
         });
 
         it('Hallintaraportit page: open error notification type and color texts', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
-          cy.get('[aria-label="error"]').click();
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="virhe"]').click();
           const typedText = 'Error texts';
           cy.get('[data-testid="slate-editor"] [contenteditable=true]')
             .type(typedText)
             .type('{selectAll}')
             .contains(typedText);
-          cy.get('[aria-label="color"]').click();
-          cy.get('[aria-label="color-picker"]').should('be.visible');
-          cy.get(`[aria-label="${Colors.darkgreen}"]`).click();
-          cy.get('[aria-label="color"]').click();
-          cy.get('[aria-label="color-picker"]').should('not.exist');
+          cy.get('[aria-label="väri"]').click();
+          cy.get('[aria-label="värivalitsin"]').should('be.visible');
+          cy.get(`[aria-label="tummanvihreä"]`).click();
+          cy.get('[aria-label="väri"]').click();
+          cy.get('[aria-label="värivalitsin"]').should('not.exist');
         });
 
         it('Hallintaraportit page: remove notification', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').click({ multiple: true, force: true });
           cy.get('[aria-label="info"]').click();
           const typedText = 'Info teksti';
           cy.get('[data-testid="slate-editor"] [contenteditable=true]')
             .type(typedText)
             .type('{selectAll}')
             .contains(typedText);
-          cy.get('[aria-label="delete"]').click();
+          cy.get('[aria-label="Poista"]').click();
         });
 
         it('Hallintaraportit page: exit editor', function () {
           cy.viewport(viewport);
           cy.visit('/muut/hallintaraportit');
-          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
-          cy.get('[aria-label="close"]').click();
-          cy.get('[aria-label="toolbar"]').should('not.exist');
+          cy.get('[aria-label="Avaa muokkausnäkymä"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="Sulje"]').click();
+          cy.get('[aria-label="työkalupalkki"]').should('not.exist');
         });
       });
     });

--- a/cypress/e2e/SlateToolbar-spec.cy.ts
+++ b/cypress/e2e/SlateToolbar-spec.cy.ts
@@ -1,0 +1,142 @@
+import { Colors } from '../../packages/frontend/src/constants/Colors';
+
+import { PresetViewports } from './constants';
+
+describe('Slate Toobar', () => {
+  PresetViewports.forEach((viewport) => {
+    describe(`on ${viewport}`, () => {
+      describe('User with read right', () => {
+        beforeEach(() => {
+          cy.intercept('GET', '**/api/database/user-right?category=hallintaraportit', {
+            fixture: 'user-read-right.json',
+          });
+        });
+
+        it('Home page: view mode', function () {
+          cy.viewport(viewport);
+          cy.visit('/');
+          cy.get('button[aria-label="open edit"]').should('not.exist');
+        });
+
+        it('Hallintaraportit page: view mode', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('button[aria-label="open edit"]').should('not.exist');
+        });
+      });
+
+      describe('User with write right', () => {
+        beforeEach(() => {
+          cy.intercept('GET', '**/api/database/user-right?category=hallintaraportit', {
+            fixture: 'user-write-right.json',
+          });
+        });
+
+        it('Home page: view mode', function () {
+          cy.viewport(viewport);
+          cy.visit('/');
+          cy.get('[aria-label="open edit"]').should('not.exist');
+        });
+
+        it('Hallintaraportit page: write mode', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').should('exist');
+        });
+
+        it('Hallintaraportit page: click on edit mode and toolbar appears', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="toolbar"]').should('exist');
+          cy.get('[aria-label="paragraph-two"]').should('exist');
+          cy.get('[aria-label="paragraph-one"]').should('exist');
+          cy.get('[aria-label="heading-two"]').should('exist');
+          cy.get('[aria-label="bold"]').should('exist');
+          cy.get('[aria-label="italic"]').should('exist');
+          cy.get('[aria-label="underlined"]').should('exist');
+          cy.get('[aria-label="numbered-list"]').should('exist');
+          cy.get('[aria-label="bulleted-list"]').should('exist');
+          cy.get('[aria-label="insert-link"]').should('exist');
+          cy.get('[aria-label="color"]').should('exist');
+          cy.get('[aria-label="info"]').should('exist');
+          cy.get('[aria-label="warning"]').should('exist');
+          cy.get('[aria-label="error"]').should('exist');
+          cy.get('[aria-label="check"]').should('exist');
+          cy.get('[aria-label="delete"]').should('exist');
+          cy.get('[aria-label="close"]').should('exist');
+        });
+
+        it('Hallintaraportit page: editor doesnt show up without any notification selection', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[data-testid="slate-editor"] [contenteditable=false]').should('exist');
+        });
+
+        it('Hallintaraportit page: open info notification and type', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="info"]').click();
+          const typedText = 'Info texts';
+          cy.get('[data-testid="slate-editor"] [contenteditable=true]').type(typedText).contains(typedText);
+        });
+
+        it('Hallintaraportit page: open warning notification and edit text format', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="warning"]').click();
+          const typedText = 'Warning texts';
+          cy.get('[data-testid="slate-editor"] [contenteditable=true]')
+            .type(typedText)
+
+            .type('{selectAll}')
+            .contains(typedText);
+          cy.get('[aria-label="bold"]').click();
+          cy.get('[aria-label="italic"]').click();
+          cy.get('[aria-label="heading-one"]').click();
+        });
+
+        it('Hallintaraportit page: open error notification type and color texts', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="error"]').click();
+          const typedText = 'Error texts';
+          cy.get('[data-testid="slate-editor"] [contenteditable=true]')
+            .type(typedText)
+            .type('{selectAll}')
+            .contains(typedText);
+          cy.get('[aria-label="color"]').click();
+          cy.get('[aria-label="color-picker"]').should('be.visible');
+          cy.get(`[aria-label="${Colors.darkgreen}"]`).click();
+          cy.get('[aria-label="color"]').click();
+          cy.get('[aria-label="color-picker"]').should('not.exist');
+        });
+
+        it('Hallintaraportit page: remove notification', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="info"]').click();
+          const typedText = 'Info teksti';
+          cy.get('[data-testid="slate-editor"] [contenteditable=true]')
+            .type(typedText)
+            .type('{selectAll}')
+            .contains(typedText);
+          cy.get('[aria-label="delete"]').click();
+        });
+
+        it('Hallintaraportit page: exit editor', function () {
+          cy.viewport(viewport);
+          cy.visit('/muut/hallintaraportit');
+          cy.get('[aria-label="open edit"]').click({ multiple: true, force: true });
+          cy.get('[aria-label="close"]').click();
+          cy.get('[aria-label="toolbar"]').should('not.exist');
+        });
+      });
+    });
+  });
+});

--- a/cypress/e2e/constants.ts
+++ b/cypress/e2e/constants.ts
@@ -1,1 +1,1 @@
-export const PresetViewports: Cypress.ViewportPreset[] = ['iphone-x', 'ipad-2', 'macbook-13', 'macbook-16'];
+export const PresetViewports: Cypress.ViewportPreset[] = ['iphone-x', 'ipad-2', 'macbook-13'];

--- a/cypress/fixtures/user-read-right.json
+++ b/cypress/fixtures/user-read-right.json
@@ -1,0 +1,4 @@
+{
+  "canRead": true,
+  "canWrite": false
+}

--- a/cypress/fixtures/user-write-right.json
+++ b/cypress/fixtures/user-write-right.json
@@ -1,0 +1,4 @@
+{
+  "canRead": true,
+  "canWrite": true
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,13 +36,18 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "npx react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": [
       "react-app",
       "react-app/jest"
+    ]
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!axios)/\""
     ]
   },
   "browserslist": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "npx react-scripts build",
-    "test": "react-scripts test --watchAll=false",
+    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/packages/frontend/src/assets/locales/fi/common.json
+++ b/packages/frontend/src/assets/locales/fi/common.json
@@ -18,7 +18,12 @@
     "load_more": "Lataa lisää",
     "save": "Tallenna",
     "reject": "Hylkää",
-    "delete": "Poista"
+    "delete": "Poista",
+    "close": "Sulje",
+    "open_edit": "Avaa muokkausnäkymä",
+    "open_search": "Avaa hakunäkymä",
+    "search": "Hae",
+    "close_modal": "Sulje modaali"
   },
   "error": {
     "500": "Jokin meni pieleen!"
@@ -48,6 +53,56 @@
     "write_content": "Kirjoita sisältö",
     "new_link": "Uusi linkki",
     "enter_url": "Anna URL-osoite",
-    "choose_color": "Valitse väri"
+    "choose_color": "Valitse väri",
+    "color": "väri",
+    "insert_link": "Lisää linkki",
+    "color_picker": "värivalitsin",
+    "toolbar": "työkalupalkki"
+  },
+  "notification": {
+    "info": "info",
+    "warning": "varoitus",
+    "error": "virhe",
+    "check": "oikein-merkki"
+  },
+  "element": {
+    "breadcrumb": "linkkipolku",
+    "bulleted-list": "numeroimaton lista",
+    "numbered-list": "numeroitu lista",
+    "heading-one": "iso otsikko",
+    "heading-two": "pienempi otsikko",
+    "list-item": "listan osio",
+    "paragraph-one": "kappale isommalla tekstikoolla",
+    "paragraph-two": "kappale normaalilla tekstikoolla",
+    "link": "linkki",
+    "notification_info": "infoilmoitus",
+    "notification_warning": "varoitusilmoitus",
+    "notification_error": "virheilmoitus",
+    "notification_confirmation": "vahvistusilmoitus"
+  },
+  "colors": {
+    "darkblue": "tummansininen",
+    "midblue": "keskisininen",
+    "lightblue": "vaaleansininen",
+    "aliceblue": "haalea sininen",
+    "cyan": "sinivihreä",
+    "lightgrey": "vaaleanharmaa",
+    "darkgrey": "tummanharmaa",
+    "white": "valkoinen",
+    "darkgreen": "tummanvihreä",
+    "lightgreen": "vaaleanvihreä",
+    "extrablack": "erittäin musta",
+    "black": "musta",
+    "darkred": "tummanpunainen",
+    "lightred": "vaalea punainen",
+    "yellow": "keltainen",
+    "pink": "vaaleanpunainen",
+    "purple": "violetti"
+  },
+  "font": {
+    "bold": "lihavoitu",
+    "italic": "kursivoitu",
+    "underlined": "alleviivattu",
+    "color": "väri"
   }
 }

--- a/packages/frontend/src/components/Breadcrumbs/index.tsx
+++ b/packages/frontend/src/components/Breadcrumbs/index.tsx
@@ -28,7 +28,7 @@ export const CustomBreadcrumbs = () => {
   });
   return (
     <Stack spacing={2}>
-      <Breadcrumbs separator=">" aria-label="breadcrumb">
+      <Breadcrumbs separator=">" aria-label={t('common:element.breadcrumb')}>
         {breadcrumbs}
       </Breadcrumbs>
     </Stack>

--- a/packages/frontend/src/components/Editor/NotificationTypes.tsx
+++ b/packages/frontend/src/components/Editor/NotificationTypes.tsx
@@ -9,9 +9,11 @@ import ConfirmIcon from '../../assets/icons/Add_vahvistus.svg';
 import { EditorContext } from '../../contexts/EditorContext';
 import { ElementType } from '../../utils/types';
 import { openNotification } from '../../utils/slateEditorUtil';
+import { useTranslation } from 'react-i18next';
 
 export const NotificationTypes = () => {
   const { editor, value, valueHandler } = useContext(EditorContext);
+  const { t } = useTranslation(['common']);
 
   const handleOpenToolbar = (notificationType: ElementType) => {
     const newValue = [{ type: notificationType, ...value }];
@@ -22,7 +24,7 @@ export const NotificationTypes = () => {
   return (
     <ContainerWrapper>
       <Box
-        aria-label="info"
+        aria-label={t('common:notification.info')}
         component="img"
         sx={{ cursor: 'pointer' }}
         src={InfoIcon}
@@ -30,7 +32,7 @@ export const NotificationTypes = () => {
         onClick={() => handleOpenToolbar(ElementType.NOTIFICATION_INFO)}
       />
       <Box
-        aria-label="warning"
+        aria-label={t('common:notification.warning')}
         component="img"
         sx={{ cursor: 'pointer' }}
         src={WarningIcon}
@@ -38,7 +40,7 @@ export const NotificationTypes = () => {
         onClick={() => handleOpenToolbar(ElementType.NOTIFICATION_WARNING)}
       />
       <Box
-        aria-label="error"
+        aria-label={t('common:notification.error')}
         component="img"
         sx={{ cursor: 'pointer' }}
         src={ErrorIcon}
@@ -46,7 +48,7 @@ export const NotificationTypes = () => {
         onClick={() => handleOpenToolbar(ElementType.NOTIFICATION_ERROR)}
       />
       <Box
-        aria-label="check"
+        aria-label={t('common:notification.check')}
         component="img"
         sx={{ cursor: 'pointer' }}
         src={ConfirmIcon}

--- a/packages/frontend/src/components/Editor/NotificationTypes.tsx
+++ b/packages/frontend/src/components/Editor/NotificationTypes.tsx
@@ -22,6 +22,7 @@ export const NotificationTypes = () => {
   return (
     <ContainerWrapper>
       <Box
+        aria-label="info"
         component="img"
         sx={{ cursor: 'pointer' }}
         src={InfoIcon}
@@ -29,6 +30,7 @@ export const NotificationTypes = () => {
         onClick={() => handleOpenToolbar(ElementType.NOTIFICATION_INFO)}
       />
       <Box
+        aria-label="warning"
         component="img"
         sx={{ cursor: 'pointer' }}
         src={WarningIcon}
@@ -36,6 +38,7 @@ export const NotificationTypes = () => {
         onClick={() => handleOpenToolbar(ElementType.NOTIFICATION_WARNING)}
       />
       <Box
+        aria-label="error"
         component="img"
         sx={{ cursor: 'pointer' }}
         src={ErrorIcon}
@@ -43,6 +46,7 @@ export const NotificationTypes = () => {
         onClick={() => handleOpenToolbar(ElementType.NOTIFICATION_ERROR)}
       />
       <Box
+        aria-label="check"
         component="img"
         sx={{ cursor: 'pointer' }}
         src={ConfirmIcon}

--- a/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
+++ b/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
@@ -60,7 +60,7 @@ export const EditorColorPicker = () => {
   );
 
   return (
-    <PopupWrapper>
+    <PopupWrapper aria-label="color">
       <HighlightedTitle>{t('common:edit.choose_color')}</HighlightedTitle>
       {colorPicker}
     </PopupWrapper>

--- a/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
+++ b/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
@@ -19,6 +19,7 @@ type ColorButtonProps = {
 export const ColorButton = ({ editor, format, color }: ColorButtonProps) => {
   return (
     <ToggleButton
+      aria-label={color}
       value={format}
       onMouseDown={(event: React.MouseEvent<HTMLElement>) => {
         event.preventDefault();
@@ -60,7 +61,7 @@ export const EditorColorPicker = () => {
   );
 
   return (
-    <PopupWrapper aria-label="color">
+    <PopupWrapper aria-label="color-picker">
       <HighlightedTitle>{t('common:edit.choose_color')}</HighlightedTitle>
       {colorPicker}
     </PopupWrapper>

--- a/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
+++ b/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
@@ -9,17 +9,19 @@ import { EditorContext } from '../../../contexts/EditorContext';
 import { toggleColor } from '../../../utils/slateEditorUtil';
 import { FontFormatType } from '../../../utils/types';
 import { HighlightedTitle } from '../../Typography/HighlightedTitle';
+import { palette } from '@mui/system';
 
 type ColorButtonProps = {
   editor: any;
   format: FontFormatType;
   color: string;
+  colorName: string;
 };
 
-export const ColorButton = ({ editor, format, color }: ColorButtonProps) => {
+export const ColorButton = ({ editor, format, color, colorName }: ColorButtonProps) => {
   return (
     <ToggleButton
-      aria-label={color}
+      aria-label={colorName}
       value={format}
       onMouseDown={(event: React.MouseEvent<HTMLElement>) => {
         event.preventDefault();
@@ -51,17 +53,23 @@ const paletteCollection = [
 export const EditorColorPicker = () => {
   const { t } = useTranslation(['common']);
   const { editor } = useContext(EditorContext);
+  const translatedColors = t(`common:colors`, { returnObjects: true });
 
-  const colorPicker = paletteCollection.map((palette: string) =>
-    ColorButton({
+  const colorPicker = paletteCollection.map((palette: string) => {
+    const colorKey = Object.keys(Colors).find(
+      (key) => Colors[key as keyof typeof Colors] === palette,
+    ) as keyof typeof translatedColors;
+
+    return ColorButton({
       editor,
       format: FontFormatType.COLOR,
       color: palette,
-    }),
-  );
+      colorName: translatedColors[colorKey],
+    });
+  });
 
   return (
-    <PopupWrapper aria-label="color-picker">
+    <PopupWrapper aria-label={t('common:edit.color_picker')}>
       <HighlightedTitle>{t('common:edit.choose_color')}</HighlightedTitle>
       {colorPicker}
     </PopupWrapper>

--- a/packages/frontend/src/components/Editor/SlateInputField.tsx
+++ b/packages/frontend/src/components/Editor/SlateInputField.tsx
@@ -28,7 +28,7 @@ export const SlateInputField = () => {
   const isNotificationSlateOpened = openToolbar && ReactEditor.isFocused(editor);
 
   return (
-    <SlateInputFieldPaperWrapper elevation={2} opentoolbar={isNotificationSlateOpened}>
+    <SlateInputFieldPaperWrapper data-testid="slate-editor" elevation={2} opentoolbar={isNotificationSlateOpened}>
       <Slate
         editor={editor}
         value={slateValue}

--- a/packages/frontend/src/components/Editor/SlateToolbar.tsx
+++ b/packages/frontend/src/components/Editor/SlateToolbar.tsx
@@ -38,9 +38,11 @@ type BlockButtonProps = {
 };
 
 const MarkButton = ({ editor, format, icon }: MarkButtonProps) => {
+  const { t } = useTranslation(['common']);
+
   return (
     <ToggleButton
-      aria-label={format}
+      aria-label={t(`common:font.${format}`)}
       value={format}
       selected={isMarkActive(editor, format)}
       onMouseDown={(event: React.MouseEvent<HTMLElement>) => {
@@ -54,9 +56,11 @@ const MarkButton = ({ editor, format, icon }: MarkButtonProps) => {
 };
 
 const BlockButton = ({ editor, format, icon }: BlockButtonProps) => {
+  const { t } = useTranslation(['common']);
+
   return (
     <ToggleButton
-      aria-label={format}
+      aria-label={t(`common:element.${format}`)}
       value={format}
       selected={isBlockActive(editor, format)}
       onMouseDown={(event: React.MouseEvent<HTMLElement>) => {
@@ -87,7 +91,7 @@ export const SlateToolbar = () => {
 
   return (
     <Slate editor={editor} value={value}>
-      <ToolbarPaperWrapper elevation={2} aria-label="toolbar">
+      <ToolbarPaperWrapper elevation={2} aria-label={t('common:edit.toolbar')}>
         <ToggleButtonGroupWrapper size="small">
           {BlockButton({
             editor,
@@ -105,7 +109,7 @@ export const SlateToolbar = () => {
           {MarkButton({ editor, format: FontFormatType.ITALIC, icon: <FormatItalicIcon fontSize="small" /> })}
           {MarkButton({ editor, format: FontFormatType.UNDERLINED, icon: <FormatUnderlinedIcon fontSize="small" /> })}
           <Box
-            aria-label="insert-link"
+            aria-label={t('common:edit.insert_link')}
             component="img"
             sx={{ cursor: 'pointer', width: '25px', padding: '7px' }}
             src={LinkIcon}
@@ -121,7 +125,7 @@ export const SlateToolbar = () => {
         </ToggleButtonGroupWrapper>
         <DividerWrapper orientation="vertical" variant="middle" flexItem />{' '}
         <Box
-          aria-label="color"
+          aria-label={t('common:edit.color')}
           component="img"
           sx={{ cursor: 'pointer', width: '25px' }}
           src={PaletteIcon}
@@ -137,7 +141,7 @@ export const SlateToolbar = () => {
         <NotificationTypes />
         <DividerWrapper orientation="vertical" variant="middle" flexItem />
         <Box
-          aria-label="delete"
+          aria-label={t('common:action.delete')}
           component="img"
           sx={{ cursor: 'pointer' }}
           src={DeleteIcon}
@@ -145,7 +149,7 @@ export const SlateToolbar = () => {
           onClick={removeNotificationOrContentType}
         />
         <Box
-          aria-label="close"
+          aria-label={t('common:action.close')}
           component="img"
           sx={{ cursor: 'pointer', marginLeft: 'auto' }}
           src={CloseIcon}

--- a/packages/frontend/src/components/Editor/SlateToolbar.tsx
+++ b/packages/frontend/src/components/Editor/SlateToolbar.tsx
@@ -87,7 +87,7 @@ export const SlateToolbar = () => {
 
   return (
     <Slate editor={editor} value={value}>
-      <ToolbarPaperWrapper elevation={2}>
+      <ToolbarPaperWrapper elevation={2} aria-label="toolbar">
         <ToggleButtonGroupWrapper size="small">
           {BlockButton({
             editor,
@@ -105,6 +105,7 @@ export const SlateToolbar = () => {
           {MarkButton({ editor, format: FontFormatType.ITALIC, icon: <FormatItalicIcon fontSize="small" /> })}
           {MarkButton({ editor, format: FontFormatType.UNDERLINED, icon: <FormatUnderlinedIcon fontSize="small" /> })}
           <Box
+            aria-label="insert-link"
             component="img"
             sx={{ cursor: 'pointer', width: '25px', padding: '7px' }}
             src={LinkIcon}
@@ -120,11 +121,11 @@ export const SlateToolbar = () => {
         </ToggleButtonGroupWrapper>
         <DividerWrapper orientation="vertical" variant="middle" flexItem />{' '}
         <Box
-          aria-label="insert-link"
+          aria-label="color"
           component="img"
           sx={{ cursor: 'pointer', width: '25px' }}
           src={PaletteIcon}
-          alt="link"
+          alt="color"
           onClick={() => setIsColorOpened(!isColorOpened)}
         />
         {isColorOpened && (

--- a/packages/frontend/src/components/Editor/SlateToolbar.tsx
+++ b/packages/frontend/src/components/Editor/SlateToolbar.tsx
@@ -40,6 +40,7 @@ type BlockButtonProps = {
 const MarkButton = ({ editor, format, icon }: MarkButtonProps) => {
   return (
     <ToggleButton
+      aria-label={format}
       value={format}
       selected={isMarkActive(editor, format)}
       onMouseDown={(event: React.MouseEvent<HTMLElement>) => {
@@ -55,6 +56,7 @@ const MarkButton = ({ editor, format, icon }: MarkButtonProps) => {
 const BlockButton = ({ editor, format, icon }: BlockButtonProps) => {
   return (
     <ToggleButton
+      aria-label={format}
       value={format}
       selected={isBlockActive(editor, format)}
       onMouseDown={(event: React.MouseEvent<HTMLElement>) => {
@@ -118,6 +120,7 @@ export const SlateToolbar = () => {
         </ToggleButtonGroupWrapper>
         <DividerWrapper orientation="vertical" variant="middle" flexItem />{' '}
         <Box
+          aria-label="insert-link"
           component="img"
           sx={{ cursor: 'pointer', width: '25px' }}
           src={PaletteIcon}
@@ -133,6 +136,7 @@ export const SlateToolbar = () => {
         <NotificationTypes />
         <DividerWrapper orientation="vertical" variant="middle" flexItem />
         <Box
+          aria-label="delete"
           component="img"
           sx={{ cursor: 'pointer' }}
           src={DeleteIcon}
@@ -140,6 +144,7 @@ export const SlateToolbar = () => {
           onClick={removeNotificationOrContentType}
         />
         <Box
+          aria-label="close"
           component="img"
           sx={{ cursor: 'pointer', marginLeft: 'auto' }}
           src={CloseIcon}

--- a/packages/frontend/src/components/Editor/__tests__/SlateInputField.test.tsx
+++ b/packages/frontend/src/components/Editor/__tests__/SlateInputField.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material';
+import { createEditor } from 'slate';
+import { createEditorWithPlugins, EditorContextProvider } from '../../../contexts/EditorContext';
+
+import { SlateInputField } from '../SlateInputField';
+import { theme } from '../../../styles/createTheme';
+import { AppBarContextProvider } from '../../../contexts/AppBarContext';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    pathname: '/',
+  }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: () => jest.fn(),
+}));
+
+const customSlatInputFieldRender = (ui: any, { providerProps, ...renderOptions }: any) => {
+  const { openToolbar = false } = providerProps;
+  const {
+    editor = createEditorWithPlugins(createEditor()),
+    value = [{ children: [{ text: '' }] }],
+    valueHandler = () => {},
+  } = providerProps;
+  return render(
+    <AppBarContextProvider openToolbar={openToolbar}>
+      <EditorContextProvider editor={editor} value={value} valueHandler={valueHandler}>
+        {ui}
+      </EditorContextProvider>
+    </AppBarContextProvider>,
+    renderOptions,
+  );
+};
+
+describe('SlateInputField component', () => {
+  let component = null as any;
+  let providerProps = null as any;
+
+  beforeEach(() => {
+    component = (
+      <ThemeProvider theme={theme}>
+        <SlateInputField />
+      </ThemeProvider>
+    );
+    providerProps = {
+      openToolbar: false,
+      value: [{ children: [{ text: '' }] }],
+    };
+  });
+
+  afterEach(() => {
+    component = null;
+    providerProps = null;
+    cleanup();
+  });
+
+  test('SlateInputField should render properly', () => {
+    render(component);
+  });
+
+  test('SlateInputField should render properly in contexts', () => {
+    customSlatInputFieldRender(component, { providerProps });
+    expect(screen.getByTestId('slate-editor')).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/Editor/__tests__/SlateToolbar.test.tsx
+++ b/packages/frontend/src/components/Editor/__tests__/SlateToolbar.test.tsx
@@ -1,0 +1,50 @@
+import { ThemeProvider } from '@mui/material';
+import { cleanup, render, screen } from '@testing-library/react';
+import renderer from 'react-test-renderer';
+
+import { theme } from '../../../styles/createTheme';
+import { SlateToolbar } from '../SlateToolbar';
+
+describe('SlateToolbar component', () => {
+  let component = null as any;
+  beforeEach(() => {
+    component = (
+      <ThemeProvider theme={theme}>
+        <SlateToolbar />
+      </ThemeProvider>
+    );
+  });
+
+  afterEach(() => {
+    component = null;
+    cleanup();
+  });
+
+  test('SlateToolbar should render properly', () => {
+    render(component);
+  });
+
+  test('SlateToolbar should match snapshot', () => {
+    const slateToolbar = renderer.create(component).toJSON();
+    expect(slateToolbar).toMatchSnapshot();
+  });
+
+  test('SlateToolbar should have a list of control buttons', () => {
+    render(component);
+    expect(screen.getByRole('button', { name: /paragraph-two/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /paragraph-one/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /heading-two/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /bold/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /italic/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /underlined/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /numbered-list/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /bulleted-list/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /insert-link/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /info/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /error/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /check/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /delete/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /close/i })).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/Editor/__tests__/SlateToolbar.test.tsx
+++ b/packages/frontend/src/components/Editor/__tests__/SlateToolbar.test.tsx
@@ -31,20 +31,22 @@ describe('SlateToolbar component', () => {
 
   test('SlateToolbar should have a list of control buttons', () => {
     render(component);
-    expect(screen.getByRole('button', { name: /paragraph-two/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /paragraph-one/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /heading-two/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /bold/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /italic/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /underlined/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /numbered-list/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /bulleted-list/i })).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /insert-link/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /kappale normaalilla tekstikoolla/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /kappale isommalla tekstikoolla/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /pienempi otsikko/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /iso otsikko/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /lihavoitu/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /kursivoitu/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /alleviivattu/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /numeroitu lista/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /numeroimaton lista/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Lisää linkki/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /väri/i })).toBeInTheDocument();
     expect(screen.getByRole('img', { name: /info/i })).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /error/i })).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /check/i })).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /delete/i })).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /close/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /varoitus/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /virhe/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /oikein-merkki/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Poista/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Sulje/i })).toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/components/Editor/__tests__/__snapshots__/SlateToolbar.test.tsx.snap
+++ b/packages/frontend/src/components/Editor/__tests__/__snapshots__/SlateToolbar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
 <div
-  aria-label="toolbar"
+  aria-label="työkalupalkki"
   className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 css-1qnc7df-MuiPaper-root"
 >
   <div
@@ -10,7 +10,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
     role="group"
   >
     <button
-      aria-label="paragraph-two"
+      aria-label="kappale normaalilla tekstikoolla"
       aria-pressed={false}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -45,7 +45,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       </svg>
     </button>
     <button
-      aria-label="paragraph-one"
+      aria-label="kappale isommalla tekstikoolla"
       aria-pressed={false}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -80,7 +80,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       </svg>
     </button>
     <button
-      aria-label="heading-two"
+      aria-label="pienempi otsikko"
       aria-pressed={false}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -115,7 +115,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       </svg>
     </button>
     <button
-      aria-label="heading-one"
+      aria-label="iso otsikko"
       aria-pressed={false}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -150,7 +150,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       </svg>
     </button>
     <button
-      aria-label="bold"
+      aria-label="lihavoitu"
       aria-pressed={null}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -185,7 +185,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       </svg>
     </button>
     <button
-      aria-label="italic"
+      aria-label="kursivoitu"
       aria-pressed={null}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -220,7 +220,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       </svg>
     </button>
     <button
-      aria-label="underlined"
+      aria-label="alleviivattu"
       aria-pressed={null}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -256,7 +256,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
     </button>
     <img
       alt="link"
-      aria-label="insert-link"
+      aria-label="Lisää linkki"
       className="MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiBox-root css-1xst3u4"
       disabled={false}
       fullWidth={false}
@@ -267,7 +267,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       src="Link.svg"
     />
     <button
-      aria-label="numbered-list"
+      aria-label="numeroitu lista"
       aria-pressed={false}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -302,7 +302,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
       </svg>
     </button>
     <button
-      aria-label="bulleted-list"
+      aria-label="numeroimaton lista"
       aria-pressed={false}
       className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
       disabled={false}
@@ -343,7 +343,7 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
    
   <img
     alt="color"
-    aria-label="color"
+    aria-label="väri"
     className="MuiBox-root css-us34y6"
     onClick={[Function]}
     src="Palette.svg"
@@ -363,21 +363,21 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
     />
     <img
       alt="warning"
-      aria-label="warning"
+      aria-label="varoitus"
       className="MuiBox-root css-4g6ai3"
       onClick={[Function]}
       src="Add_varoitus.svg"
     />
     <img
       alt="error"
-      aria-label="error"
+      aria-label="virhe"
       className="MuiBox-root css-4g6ai3"
       onClick={[Function]}
       src="Add_virhe.svg"
     />
     <img
       alt="check"
-      aria-label="check"
+      aria-label="oikein-merkki"
       className="MuiBox-root css-4g6ai3"
       onClick={[Function]}
       src="Add_vahvistus.svg"
@@ -388,14 +388,14 @@ exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
   />
   <img
     alt="delete"
-    aria-label="delete"
+    aria-label="Poista"
     className="MuiBox-root css-4g6ai3"
     onClick={[Function]}
     src="Delete.svg"
   />
   <img
     alt="close"
-    aria-label="close"
+    aria-label="Sulje"
     className="MuiBox-root css-1yceefw"
     onClick={[Function]}
     src="Close.svg"

--- a/packages/frontend/src/components/Editor/__tests__/__snapshots__/SlateToolbar.test.tsx.snap
+++ b/packages/frontend/src/components/Editor/__tests__/__snapshots__/SlateToolbar.test.tsx.snap
@@ -1,0 +1,403 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
+<div
+  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 css-1qnc7df-MuiPaper-root"
+>
+  <div
+    className="MuiToggleButtonGroup-root css-4hldsh-MuiToggleButtonGroup-root"
+    role="group"
+  >
+    <button
+      aria-label="paragraph-two"
+      aria-pressed={false}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="paragraph-two"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1dttty6-MuiSvgIcon-root"
+        data-testid="FormatSizeIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9 4v3h5v12h3V7h5V4H9zm-6 8h3v7h3v-7h3V9H3v3z"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="paragraph-one"
+      aria-pressed={false}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="paragraph-one"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-wde5sp-MuiSvgIcon-root"
+        data-testid="FormatSizeIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9 4v3h5v12h3V7h5V4H9zm-6 8h3v7h3v-7h3V9H3v3z"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="heading-two"
+      aria-pressed={false}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="heading-two"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1y543ej-MuiSvgIcon-root"
+        data-testid="FormatSizeIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9 4v3h5v12h3V7h5V4H9zm-6 8h3v7h3v-7h3V9H3v3z"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="heading-one"
+      aria-pressed={false}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="heading-one"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-g7wpym-MuiSvgIcon-root"
+        data-testid="FormatSizeIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9 4v3h5v12h3V7h5V4H9zm-6 8h3v7h3v-7h3V9H3v3z"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="bold"
+      aria-pressed={null}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="bold"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-y3v3gx-MuiSvgIcon-root"
+        data-testid="FormatBoldIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H7v14h7.04c2.09 0 3.71-1.7 3.71-3.79 0-1.52-.86-2.82-2.15-3.42zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="italic"
+      aria-pressed={null}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="italic"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-y3v3gx-MuiSvgIcon-root"
+        data-testid="FormatItalicIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M10 4v3h2.21l-3.42 8H6v3h8v-3h-2.21l3.42-8H18V4z"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="underlined"
+      aria-pressed={null}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="underlined"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-y3v3gx-MuiSvgIcon-root"
+        data-testid="FormatUnderlinedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z"
+        />
+      </svg>
+    </button>
+    <img
+      alt="link"
+      aria-label="insert-link"
+      className="MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiBox-root css-1xst3u4"
+      disabled={false}
+      fullWidth={false}
+      onChange={[Function]}
+      onClick={[Function]}
+      selected={false}
+      size="small"
+      src="Link.svg"
+    />
+    <button
+      aria-label="numbered-list"
+      aria-pressed={false}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="numbered-list"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-y3v3gx-MuiSvgIcon-root"
+        data-testid="FormatListNumberedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M2 17h2v.5H3v1h1v.5H2v1h3v-4H2v1zm1-9h1V4H2v1h1v3zm-1 3h1.8L2 13.1v.9h3v-1H3.2L5 10.9V10H2v1zm5-6v2h14V5H7zm0 14h14v-2H7v2zm0-6h14v-2H7v2z"
+        />
+      </svg>
+    </button>
+    <button
+      aria-label="bulleted-list"
+      aria-pressed={false}
+      className="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-aaezgw-MuiButtonBase-root-MuiToggleButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+      value="bulleted-list"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-y3v3gx-MuiSvgIcon-root"
+        data-testid="FormatListBulletedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M4 10.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5zm0-6c-.83 0-1.5.67-1.5 1.5S3.17 7.5 4 7.5 5.5 6.83 5.5 6 4.83 4.5 4 4.5zm0 12c-.83 0-1.5.68-1.5 1.5s.68 1.5 1.5 1.5 1.5-.68 1.5-1.5-.67-1.5-1.5-1.5zM7 19h14v-2H7v2zm0-6h14v-2H7v2zm0-8v2h14V5H7z"
+        />
+      </svg>
+    </button>
+  </div>
+  <hr
+    className="MuiDivider-root MuiDivider-middle MuiDivider-vertical MuiDivider-flexItem css-1dpfv1n-MuiDivider-root"
+  />
+   
+  <img
+    alt="color"
+    aria-label="color"
+    className="MuiBox-root css-us34y6"
+    onClick={[Function]}
+    src="Palette.svg"
+  />
+  <hr
+    className="MuiDivider-root MuiDivider-middle MuiDivider-vertical MuiDivider-flexItem css-1dpfv1n-MuiDivider-root"
+  />
+  <div
+    className="css-2eparj"
+  >
+    <img
+      alt="info"
+      aria-label="info"
+      className="MuiBox-root css-4g6ai3"
+      onClick={[Function]}
+      src="Add_info.svg"
+    />
+    <img
+      alt="warning"
+      aria-label="warning"
+      className="MuiBox-root css-4g6ai3"
+      onClick={[Function]}
+      src="Add_varoitus.svg"
+    />
+    <img
+      alt="error"
+      aria-label="error"
+      className="MuiBox-root css-4g6ai3"
+      onClick={[Function]}
+      src="Add_virhe.svg"
+    />
+    <img
+      alt="check"
+      aria-label="check"
+      className="MuiBox-root css-4g6ai3"
+      onClick={[Function]}
+      src="Add_vahvistus.svg"
+    />
+  </div>
+  <hr
+    className="MuiDivider-root MuiDivider-middle MuiDivider-vertical MuiDivider-flexItem css-1dpfv1n-MuiDivider-root"
+  />
+  <img
+    alt="delete"
+    aria-label="delete"
+    className="MuiBox-root css-4g6ai3"
+    onClick={[Function]}
+    src="Delete.svg"
+  />
+  <img
+    alt="close"
+    aria-label="close"
+    className="MuiBox-root css-1yceefw"
+    onClick={[Function]}
+    src="Close.svg"
+  />
+</div>
+`;

--- a/packages/frontend/src/components/Editor/__tests__/__snapshots__/SlateToolbar.test.tsx.snap
+++ b/packages/frontend/src/components/Editor/__tests__/__snapshots__/SlateToolbar.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`SlateToolbar component SlateToolbar should match snapshot 1`] = `
 <div
+  aria-label="toolbar"
   className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 css-1qnc7df-MuiPaper-root"
 >
   <div

--- a/packages/frontend/src/components/Files/CategoryFiles.tsx
+++ b/packages/frontend/src/components/Files/CategoryFiles.tsx
@@ -1,5 +1,4 @@
 import { NodeItem } from './File';
-import { getCategoryRouteName, getRouterName } from '../../utils/helpers';
 import { ErrorMessage } from '../Notification/ErrorMessage';
 import { Spinner } from '../Spinner';
 import { useCallback, useContext, useEffect, useState } from 'react';
@@ -13,6 +12,7 @@ import axios from 'axios';
 import { FileDeleteDialogButton } from './FileDeleteDialogButton';
 import { useLocation } from 'react-router-dom';
 import { AppBarContext } from '../../contexts/AppBarContext';
+import { getCategoryRouteName } from '../../routes';
 
 type TCategoryFilesProps = {
   subCategory?: string;

--- a/packages/frontend/src/components/Modal/FileModal.tsx
+++ b/packages/frontend/src/components/Modal/FileModal.tsx
@@ -44,8 +44,7 @@ export const FileModal: FunctionComponent<ModalProps> = ({
               <IconButton
                 sx={{ color: Colors.extrablack, marginRight: '-10px' }}
                 edge="end"
-                size="small"
-                area-label="close-modal"
+                aria-label={t('common:action.close_modal')}
                 onClick={() => handleClose()}
               >
                 <Close></Close>

--- a/packages/frontend/src/components/NavBar/DesktopAppBar.tsx
+++ b/packages/frontend/src/components/NavBar/DesktopAppBar.tsx
@@ -27,7 +27,13 @@ export const DesktopAppBar = () => {
         <CustomBreadcrumbs />
         <Box sx={{ flexGrow: 1 }} />
         {shouldEdit && (
-          <EditButtonWrapper size="large" color="primary" variant="contained" onClick={openToolbarHandler}>
+          <EditButtonWrapper
+            size="large"
+            color="primary"
+            variant="contained"
+            onClick={openToolbarHandler}
+            aria-label="open edit"
+          >
             <EditIcon fontSize="small" />
             {t('common:edit.edit_content')}
           </EditButtonWrapper>

--- a/packages/frontend/src/components/NavBar/DesktopAppBar.tsx
+++ b/packages/frontend/src/components/NavBar/DesktopAppBar.tsx
@@ -32,7 +32,7 @@ export const DesktopAppBar = () => {
             color="primary"
             variant="contained"
             onClick={openToolbarHandler}
-            aria-label="open edit"
+            aria-label={t('common:action.open_edit')}
           >
             <EditIcon fontSize="small" />
             {t('common:edit.edit_content')}

--- a/packages/frontend/src/components/NavBar/MiniAppBar.tsx
+++ b/packages/frontend/src/components/NavBar/MiniAppBar.tsx
@@ -42,11 +42,11 @@ export const MiniAppBar = () => {
         </Link>
         <Box sx={{ flexGrow: 1 }} />
         {shouldEdit && (
-          <IconButton size="large" edge="end" color="inherit" area-label="open edit" onClick={openToolbarHandler}>
+          <IconButton size="large" edge="end" color="inherit" aria-label="open edit" onClick={openToolbarHandler}>
             <EditIcon fontSize="small" color="primary" />
           </IconButton>
         )}
-        <IconButton size="large" edge="end" color="inherit" area-label="open search" onClick={toggleSearch}>
+        <IconButton size="large" edge="end" color="inherit" aria-label="open search" onClick={toggleSearch}>
           <SearchIcon color="primary" />
         </IconButton>
       </>

--- a/packages/frontend/src/components/NavBar/MiniAppBar.tsx
+++ b/packages/frontend/src/components/NavBar/MiniAppBar.tsx
@@ -14,6 +14,7 @@ import { useContext } from 'react';
 import { AppBarContext } from '../../contexts/AppBarContext';
 import { Link } from 'react-router-dom';
 import { Routes } from '../../constants/Routes';
+import { useTranslation } from 'react-i18next';
 
 export const MiniAppBar = () => {
   const { openDrawer, toggleDrawer, openSearch, toggleSearch, openEdit, openToolbar, openToolbarHandler, userRight } =
@@ -21,6 +22,7 @@ export const MiniAppBar = () => {
 
   const userWriteRight = userRight.canWrite;
   const shouldEdit = userWriteRight && !openEdit && !openToolbar;
+  const { t } = useTranslation(['common']);
 
   const MainAppBar = () => {
     return (
@@ -42,11 +44,23 @@ export const MiniAppBar = () => {
         </Link>
         <Box sx={{ flexGrow: 1 }} />
         {shouldEdit && (
-          <IconButton size="large" edge="end" color="inherit" aria-label="open edit" onClick={openToolbarHandler}>
+          <IconButton
+            size="large"
+            edge="end"
+            color="inherit"
+            aria-label={t('common:action.open_edit')}
+            onClick={openToolbarHandler}
+          >
             <EditIcon fontSize="small" color="primary" />
           </IconButton>
         )}
-        <IconButton size="large" edge="end" color="inherit" aria-label="open search" onClick={toggleSearch}>
+        <IconButton
+          size="large"
+          edge="end"
+          color="inherit"
+          aria-label={t('common:action.open_search')}
+          onClick={toggleSearch}
+        >
           <SearchIcon color="primary" />
         </IconButton>
       </>

--- a/packages/frontend/src/components/NavBar/__tests__/MenuList.test.tsx
+++ b/packages/frontend/src/components/NavBar/__tests__/MenuList.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import renderer, { act } from 'react-test-renderer';
-import { AppBarContextProvider } from '../../../contexts/AppBarContext';
 import { MenuContextProvider } from '../../../contexts/MenuContext';
 import { MenuList } from '../MenuList';
 
@@ -11,21 +10,11 @@ jest.mock('react-router-dom', () => ({
 }));
 
 test('MenuList renders properly', () => {
-  render(
-    <AppBarContextProvider openDrawer={true}>
-      <MenuList />
-    </AppBarContextProvider>,
-  );
+  render(<MenuList />);
 });
 
 test('MenuList matches snapshot', () => {
-  const menuList = renderer
-    .create(
-      <AppBarContextProvider openDrawer={false}>
-        <MenuList />
-      </AppBarContextProvider>,
-    )
-    .toJSON();
+  const menuList = renderer.create(<MenuList />).toJSON();
   expect(menuList).toMatchSnapshot();
 });
 
@@ -44,5 +33,5 @@ test('MenuList, open a menu and check that new item is visible', async () => {
   });
   const lineCharts = screen.getByText('Linjakaaviot').closest('a'); // eslint-disable-line testing-library/no-node-access
   expect(lineCharts).toBeVisible();
-  expect(lineCharts).toHaveAttribute('href', '/linjakaaviot');
+  expect(lineCharts).toHaveAttribute('href', '/kaaviot/linjakaaviot');
 });

--- a/packages/frontend/src/components/Search/index.tsx
+++ b/packages/frontend/src/components/Search/index.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom';
 import { Routes } from '../../constants/Routes';
 import { FilterSearch } from './FilterSearch';
 import { AppBarContext } from '../../contexts/AppBarContext';
+import { useTranslation } from 'react-i18next';
 
 type SearchProps = {
   isDesktop?: boolean;
@@ -26,6 +27,7 @@ export const Search = ({ isDesktop = false }: SearchProps) => {
   const { query, queryHandler } = searchContext;
   const { openSearch, toggleSearch, openFilter, toggleFilter } = useContext(AppBarContext);
   const navigate = useNavigate();
+  const { t } = useTranslation(['common']);
 
   const closeSearch = () => {
     openSearch && toggleSearch();
@@ -82,7 +84,7 @@ export const Search = ({ isDesktop = false }: SearchProps) => {
           inputRef={(input) => openSearch && input?.focus()}
           fullWidth={true}
           placeholder="Etsi sivustolta"
-          inputProps={{ 'aria-label': 'search' }}
+          inputProps={{ 'aria-label': t('common:action.search') }}
           value={query}
           onChange={(event) => queryHandler(event.target.value)}
           onKeyDown={(event) => enterSearch(event)}

--- a/packages/frontend/src/contexts/AppBarContext.tsx
+++ b/packages/frontend/src/contexts/AppBarContext.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useGetUserRightPageContent } from '../hooks/query/GetUserRightPageContent';
-import { getCategoryRouteName } from '../utils/helpers';
+import { getCategoryRouteName } from '../routes';
 
 export const AppBarContext = React.createContext({
   openDrawer: false,

--- a/packages/frontend/src/contexts/EditorContext.tsx
+++ b/packages/frontend/src/contexts/EditorContext.tsx
@@ -11,7 +11,7 @@ import { isSlateValueEmpty, openNotification } from '../utils/slateEditorUtil';
 import { ElementType } from '../utils/types';
 import withLinks from '../plugins/withLinks';
 
-const createEditorWithPlugins = pipe(withReact, withLinks);
+export const createEditorWithPlugins = pipe(withReact, withLinks);
 
 export const EditorContext = React.createContext({
   editor: createEditorWithPlugins(createEditor()),

--- a/packages/frontend/src/i18n.ts
+++ b/packages/frontend/src/i18n.ts
@@ -23,7 +23,7 @@ export const resources = {
 i18next.use(initReactI18next).init({
   lng: 'fi', // override any language detector and use Finnish as default. Remove this if you need localization in the future.
   fallbackLng: 'fi',
-  debug: true,
+  debug: false, // turn off for running unit tests
   resources,
   defaultNS,
 });

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -22,7 +22,7 @@ export const queryClient = new QueryClient({
   },
 });
 
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+const root = ReactDOM.createRoot(document.getElementById('root') || document.createElement('div')); // for testing purposes
 root.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>

--- a/packages/frontend/src/pages/ProtectedPage/index.tsx
+++ b/packages/frontend/src/pages/ProtectedPage/index.tsx
@@ -7,10 +7,10 @@ import { AppBarContext } from '../../contexts/AppBarContext';
 import { SlateInputField } from '../../components/Editor/SlateInputField';
 import { EditorContext } from '../../contexts/EditorContext';
 import { isSlateValueEmpty } from '../../utils/slateEditorUtil';
-import { getCategoryRouteName } from '../../utils/helpers';
 import { FileUploadDialogButton } from '../../components/Files/FileUploadDialogButton';
 import { useLocation } from 'react-router-dom';
 import { CategoryFiles } from '../../components/Files/CategoryFiles';
+import { getCategoryRouteName } from '../../routes';
 
 type Props = {
   children: React.ReactElement;

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouteObject } from 'react-router-dom';
+import { createBrowserRouter, Location, matchRoutes, RouteObject } from 'react-router-dom';
 
 import { Landing } from './pages/Landing';
 import { Routes } from './constants/Routes';
@@ -31,6 +31,20 @@ import { DriverActivity } from './pages/Others/DriverActivity';
 import { PlanningArchive } from './pages/Others/PlanningArchive';
 import { RailwayMonitoringService } from './pages/Others/RailwayMonitoringService';
 import { AppContextProvider } from './contexts/AppContextProvider';
+
+/**
+ * Return router name based on page title's name
+ * @param location
+ * @returns string
+ */
+export const getCategoryRouteName = (location: Location) => {
+  const routeMatch = matchRoutes(categoryRoutes, location);
+  if (routeMatch) {
+    const path = routeMatch[0].route.path as string;
+    return path.split('/').pop() as string;
+  }
+  return '';
+};
 
 const getProtectedRoute = (path: string, component: JSX.Element): RouteObject => ({
   path: path,

--- a/packages/frontend/src/utils/helpers.ts
+++ b/packages/frontend/src/utils/helpers.ts
@@ -4,6 +4,8 @@ import { FileSizeUnit, LocaleLang, LocaleUnit } from '../constants/Units';
 import { Sorting } from '../contexts/SearchContext';
 import categoryData from '../assets/data/FinnishCategories.json';
 import { MainCategoryData, SubCategoryData } from '../types/types';
+import { matchRoutes } from 'react-router-dom';
+import { categoryRoutes } from '../routes';
 
 /**
  * Generate range of years
@@ -84,7 +86,7 @@ type TranslatedCategoryData = { category: string; subCategories: string[] };
  * @returns Array
  */
 export const getTranslatedCategoryData = (categoryData: CategoryDataParameter[]): TranslatedCategoryData[] => {
-  return categoryData.map((item: CategoryDataParameter) => {
+  return (categoryData || []).map((item: CategoryDataParameter) => {
     const categoryName = Object.values(item.category)[0];
     const subCategoryNames = Object.values(item.subCategories);
     return { category: categoryName, subCategories: subCategoryNames };
@@ -96,7 +98,7 @@ export const getTranslatedCategoryData = (categoryData: CategoryDataParameter[])
  * @returns
  */
 export const getMainCategoryData = (): MainCategoryData => {
-  return categoryData.reduce((mainCategories: object, item: CategoryDataParameter) => {
+  return (categoryData || []).reduce((mainCategories: object, item: CategoryDataParameter) => {
     mainCategories = { ...mainCategories, ...item.category };
     return mainCategories;
   }, {}) as MainCategoryData;
@@ -107,7 +109,7 @@ export const getMainCategoryData = (): MainCategoryData => {
  * @returns object
  */
 export const getSubCategoryData = (): SubCategoryData => {
-  return categoryData.reduce((subCategories: object, item: CategoryDataParameter) => {
+  return (categoryData || []).reduce((subCategories: object, item: CategoryDataParameter) => {
     subCategories = { ...subCategories, ...item.subCategories };
     return subCategories;
   }, {}) as SubCategoryData;
@@ -118,11 +120,11 @@ export const getSubCategoryData = (): SubCategoryData => {
  * @param name
  * @returns
  */
-export const getRouterName = (name: string) => {
+export const getRouterName = (name: string = '') => {
   return name.replace(/\s/g, '-').replace(/[()]/g, '').toLowerCase().replace(/ä/g, 'a').replace(/ö/g, 'o');
 };
 
 // TODO: should return original page's title
-export const parseRouterName = (routerName: string) => {
+export const parseRouterName = (routerName: string = '') => {
   return routerName.replace(/-/g, ' ');
 };

--- a/packages/frontend/src/utils/helpers.ts
+++ b/packages/frontend/src/utils/helpers.ts
@@ -4,8 +4,6 @@ import { FileSizeUnit, LocaleLang, LocaleUnit } from '../constants/Units';
 import { Sorting } from '../contexts/SearchContext';
 import categoryData from '../assets/data/FinnishCategories.json';
 import { MainCategoryData, SubCategoryData } from '../types/types';
-import { matchRoutes, Location } from 'react-router-dom';
-import { categoryRoutes } from '../routes';
 
 /**
  * Generate range of years
@@ -127,18 +125,4 @@ export const getRouterName = (name: string) => {
 // TODO: should return original page's title
 export const parseRouterName = (routerName: string) => {
   return routerName.replace(/-/g, ' ');
-};
-
-/**
- * Return router name based on page title's name
- * @param location
- * @returns string
- */
-export const getCategoryRouteName = (location: Location) => {
-  const routeMatch = matchRoutes(categoryRoutes, location);
-  if (routeMatch) {
-    const path = routeMatch[0].route.path as string;
-    return path.split('/').pop() as string;
-  }
-  return '';
 };


### PR DESCRIPTION
- Move `getCategoryRouteName` away from helper file as Jest failed to run
- Unit test for SlateToolbar and SlateInputField
- Cypress test for SlateToolbar and SlateInputField