### PR TITLE
Feat/RTENU-194 card editor

### DIFF
--- a/packages/frontend/src/assets/locales/fi/common.json
+++ b/packages/frontend/src/assets/locales/fi/common.json
@@ -78,7 +78,9 @@
     "notification_info": "infoilmoitus",
     "notification_warning": "varoitusilmoitus",
     "notification_error": "virheilmoitus",
-    "notification_confirmation": "vahvistusilmoitus"
+    "notification_confirmation": "vahvistusilmoitus",
+    "card": "kortti",
+    "card_title": "kortin otsikko"
   },
   "colors": {
     "darkblue": "tummansininen",

--- a/packages/frontend/src/assets/locales/fi/common.json
+++ b/packages/frontend/src/assets/locales/fi/common.json
@@ -80,7 +80,9 @@
     "notification_error": "virheilmoitus",
     "notification_confirmation": "vahvistusilmoitus",
     "card": "kortti",
-    "card_title": "kortin otsikko"
+    "card_title": "kortin otsikko",
+    "text": "teksti",
+    "file": "tiedosto"
   },
   "colors": {
     "darkblue": "tummansininen",
@@ -106,5 +108,12 @@
     "italic": "kursivoitu",
     "underlined": "alleviivattu",
     "color": "väri"
+  },
+  "card": {
+    "contact_information": "Yhteystiedot",
+    "responsibility": "Vastuu",
+    "name": "Henkilö nimi",
+    "phone_number": "Puhelinnumero",
+    "email": "Sähköpostiosoite"
   }
 }

--- a/packages/frontend/src/components/Editor/Cards/ContactEditorCard.tsx
+++ b/packages/frontend/src/components/Editor/Cards/ContactEditorCard.tsx
@@ -14,7 +14,7 @@ const ContactEditorCardPaperWrapper = styled(Paper)<DrawerWrapperProps>(({ theme
   padding: '20px',
   display: 'inline-block',
   verticalAlign: 'top',
-  margin: '10px',
+  margin: '0 20px 20px 0',
   [theme.breakpoints.only('mobile')]: {
     width: '85%',
   },

--- a/packages/frontend/src/components/Editor/Cards/ContactEditorCard.tsx
+++ b/packages/frontend/src/components/Editor/Cards/ContactEditorCard.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { DrawerWrapperProps } from '../../NavBar/DesktopDrawer';
+import { Paper } from '@mui/material';
+import { SlateElementProps } from '../../../utils/slateEditorUtil';
+import { Colors } from '../../../constants/Colors';
+
+export const ContactEditorCard = ({ attributes, children, element }: SlateElementProps) => {
+  return <ContactEditorCardPaperWrapper {...attributes}>{children}</ContactEditorCardPaperWrapper>;
+};
+
+const ContactEditorCardPaperWrapper = styled(Paper)<DrawerWrapperProps>(({ theme }) => ({
+  backgroundColor: Colors.lightgrey,
+  minHeight: '100px',
+  padding: '20px',
+  display: 'inline-block',
+  verticalAlign: 'top',
+  margin: '10px',
+  [theme.breakpoints.only('mobile')]: {
+    width: '85%',
+  },
+  [theme.breakpoints.only('tablet')]: {
+    width: '90%',
+  },
+  [theme.breakpoints.only('desktop')]: {
+    width: '40%',
+  },
+}));

--- a/packages/frontend/src/components/Editor/ConfirmationAppBar.tsx
+++ b/packages/frontend/src/components/Editor/ConfirmationAppBar.tsx
@@ -11,7 +11,6 @@ import { EditorContext } from '../../contexts/EditorContext';
 import { useLocation } from 'react-router-dom';
 import { useUpdatePageContents } from '../../hooks/mutations/UpdateCategoryPageContent';
 import { getRouterName } from '../../utils/helpers';
-import { isSlateValueEmpty } from '../../utils/slateEditorUtil';
 import { SnackbarAlert } from '../Notification/Snackbar';
 
 export const ConfirmationAppBar = () => {

--- a/packages/frontend/src/components/Editor/ContentTypes.tsx
+++ b/packages/frontend/src/components/Editor/ContentTypes.tsx
@@ -37,7 +37,7 @@ export const ContentTypes = () => {
         onClick={contactCardHandler}
       />
       <Box
-        aria-label="teksti"
+        aria-label={t('common:element.text')}
         component="img"
         sx={{ cursor: 'pointer' }}
         src={TextIcon}
@@ -45,7 +45,7 @@ export const ContentTypes = () => {
         onClick={paragraphHandler}
       />
       <Box
-        aria-label="tiedosto"
+        aria-label={t('common:element.file')}
         component="img"
         sx={{ cursor: 'pointer' }}
         src={FolderIcon}

--- a/packages/frontend/src/components/Editor/ContentTypes.tsx
+++ b/packages/frontend/src/components/Editor/ContentTypes.tsx
@@ -1,0 +1,51 @@
+import { Box } from '@mui/material';
+import { useContext } from 'react';
+
+import TextIcon from '../../assets/icons/Add_teksti.svg';
+import CardIcon from '../../assets/icons/Add_kortti.svg';
+import FolderIcon from '../../assets/icons/Add_tiedosto.svg';
+import { ElementType } from '../../utils/types';
+import { openContactCard, openText } from '../../utils/slateEditorUtil';
+import { useTranslation } from 'react-i18next';
+import { EditorContext } from '../../contexts/EditorContext';
+import { TypeContainerWrapper } from './NotificationTypes';
+
+export const ContentTypes = () => {
+  const { editor } = useContext(EditorContext);
+  const { t } = useTranslation(['common']);
+
+  const contactCardHandler = () => {
+    openContactCard(editor, ElementType.CARD);
+  };
+
+  return (
+    <TypeContainerWrapper>
+      <Box
+        aria-label={t('common:element.card')}
+        component="img"
+        sx={{ cursor: 'pointer' }}
+        src={CardIcon}
+        alt="card"
+        onClick={() => {
+          contactCardHandler();
+        }}
+      />
+      <Box
+        aria-label="teksti"
+        component="img"
+        sx={{ cursor: 'pointer' }}
+        src={TextIcon}
+        alt="text"
+        onClick={() => openText(editor, ElementType.PARAGRAPH_TWO)}
+      />
+      <Box
+        aria-label="tiedosto"
+        component="img"
+        sx={{ cursor: 'pointer' }}
+        src={FolderIcon}
+        alt="folder"
+        onClick={() => console.log('// TODO: Add folder')}
+      />
+    </TypeContainerWrapper>
+  );
+};

--- a/packages/frontend/src/components/Editor/ContentTypes.tsx
+++ b/packages/frontend/src/components/Editor/ContentTypes.tsx
@@ -5,17 +5,25 @@ import TextIcon from '../../assets/icons/Add_teksti.svg';
 import CardIcon from '../../assets/icons/Add_kortti.svg';
 import FolderIcon from '../../assets/icons/Add_tiedosto.svg';
 import { ElementType } from '../../utils/types';
-import { openContactCard, openText } from '../../utils/slateEditorUtil';
+import { insertParagraph, openContactCard } from '../../utils/slateEditorUtil';
 import { useTranslation } from 'react-i18next';
 import { EditorContext } from '../../contexts/EditorContext';
 import { TypeContainerWrapper } from './NotificationTypes';
 
 export const ContentTypes = () => {
-  const { editor } = useContext(EditorContext);
+  const { editor, value, valueHandler } = useContext(EditorContext);
   const { t } = useTranslation(['common']);
 
   const contactCardHandler = () => {
+    const newValue = [{ type: ElementType.CARD, ...value }];
+    valueHandler(newValue);
     openContactCard(editor, ElementType.CARD);
+  };
+
+  const paragraphHandler = () => {
+    const newValue = [{ type: ElementType.PARAGRAPH_TWO, ...value }];
+    valueHandler(newValue);
+    insertParagraph(editor, ElementType.PARAGRAPH_TWO);
   };
 
   return (
@@ -26,9 +34,7 @@ export const ContentTypes = () => {
         sx={{ cursor: 'pointer' }}
         src={CardIcon}
         alt="card"
-        onClick={() => {
-          contactCardHandler();
-        }}
+        onClick={contactCardHandler}
       />
       <Box
         aria-label="teksti"
@@ -36,7 +42,7 @@ export const ContentTypes = () => {
         sx={{ cursor: 'pointer' }}
         src={TextIcon}
         alt="text"
-        onClick={() => openText(editor, ElementType.PARAGRAPH_TWO)}
+        onClick={paragraphHandler}
       />
       <Box
         aria-label="tiedosto"

--- a/packages/frontend/src/components/Editor/NotificationTypes.tsx
+++ b/packages/frontend/src/components/Editor/NotificationTypes.tsx
@@ -22,7 +22,7 @@ export const NotificationTypes = () => {
   };
 
   return (
-    <ContainerWrapper>
+    <TypeContainerWrapper>
       <Box
         aria-label={t('common:notification.info')}
         component="img"
@@ -55,14 +55,9 @@ export const NotificationTypes = () => {
         alt="check"
         onClick={() => handleOpenToolbar(ElementType.NOTIFICATION_CONFIRMATION)}
       />
-    </ContainerWrapper>
+    </TypeContainerWrapper>
   );
 };
-
-const ContainerWrapper = styled('div')(({ theme }) => ({
-  textAlign: 'center',
-  marginTop: '5px',
-  [theme.breakpoints.only('desktop')]: {
-    marginTop: '20px',
-  },
+export const TypeContainerWrapper = styled('div')(() => ({
+  display: 'flex',
 }));

--- a/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
+++ b/packages/frontend/src/components/Editor/Popup/EditorColorPicker.tsx
@@ -9,7 +9,6 @@ import { EditorContext } from '../../../contexts/EditorContext';
 import { toggleColor } from '../../../utils/slateEditorUtil';
 import { FontFormatType } from '../../../utils/types';
 import { HighlightedTitle } from '../../Typography/HighlightedTitle';
-import { palette } from '@mui/system';
 
 type ColorButtonProps = {
   editor: any;

--- a/packages/frontend/src/components/Editor/Popup/LinkPopup.tsx
+++ b/packages/frontend/src/components/Editor/Popup/LinkPopup.tsx
@@ -3,10 +3,11 @@ import { Box } from '@mui/material';
 import { useFocused, useSelected, useSlateStatic } from 'slate-react';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
-import { ILinkElement, removeLink, SlateElementProps } from '../../../utils/slateEditorUtil';
+import { removeLink, SlateElementProps } from '../../../utils/slateEditorUtil';
 import LinkOffIcon from '../../../assets/icons/LinkOff.svg';
 import { useContext } from 'react';
 import { AppBarContext } from '../../../contexts/AppBarContext';
+import { ILinkElement } from '../../../utils/types';
 
 interface LinkPopupProps extends SlateElementProps {}
 

--- a/packages/frontend/src/components/Editor/SlateToolbar.tsx
+++ b/packages/frontend/src/components/Editor/SlateToolbar.tsx
@@ -8,18 +8,10 @@ import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
 import { Slate } from 'slate-react';
 
-import DeleteIcon from '../../assets/icons/Delete.svg';
 import CloseIcon from '../../assets/icons/Close.svg';
 import LinkIcon from '../../assets/icons/Link.svg';
 import PaletteIcon from '../../assets/icons/Palette.svg';
-import {
-  deleteNotification,
-  insertLink,
-  isBlockActive,
-  isMarkActive,
-  toggleBlock,
-  toggleMark,
-} from '../../utils/slateEditorUtil';
+import { insertLink, isBlockActive, isMarkActive, toggleBlock, toggleMark } from '../../utils/slateEditorUtil';
 import { Colors } from '../../constants/Colors';
 import { ElementType, FontFormatType } from '../../utils/types';
 import { NotificationTypes } from './NotificationTypes';
@@ -80,10 +72,6 @@ export const SlateToolbar = () => {
   const { editor, value } = useContext(EditorContext);
   const [isColorOpened, setIsColorOpened] = useState(false);
 
-  const removeNotificationOrContentType = () => {
-    deleteNotification(editor, value[0].type, true);
-  };
-
   const handleInsertLink = () => {
     const url = prompt(t('common:edit.enter_url'));
     if (!url) return;
@@ -143,14 +131,6 @@ export const SlateToolbar = () => {
         <DividerWrapper orientation="vertical" variant="middle" flexItem />
         <ContentTypes />
         <DividerWrapper orientation="vertical" variant="middle" flexItem />
-        <Box
-          aria-label={t('common:action.delete')}
-          component="img"
-          sx={{ cursor: 'pointer' }}
-          src={DeleteIcon}
-          alt="delete"
-          onClick={removeNotificationOrContentType}
-        />
         <Box
           aria-label={t('common:action.close')}
           component="img"

--- a/packages/frontend/src/components/Editor/SlateToolbar.tsx
+++ b/packages/frontend/src/components/Editor/SlateToolbar.tsx
@@ -28,6 +28,7 @@ import { AppBarContext } from '../../contexts/AppBarContext';
 import { EditorContext } from '../../contexts/EditorContext';
 import { useTranslation } from 'react-i18next';
 import { EditorColorPicker } from './Popup/EditorColorPicker';
+import { ContentTypes } from './ContentTypes';
 
 type MarkButtonProps = { editor: any; format: FontFormatType; icon: any };
 
@@ -90,7 +91,7 @@ export const SlateToolbar = () => {
   };
 
   return (
-    <Slate editor={editor} value={value}>
+    <Slate editor={editor} value={value} onChange={() => {}}>
       <ToolbarPaperWrapper elevation={2} aria-label={t('common:edit.toolbar')}>
         <ToggleButtonGroupWrapper size="small">
           {BlockButton({
@@ -139,6 +140,8 @@ export const SlateToolbar = () => {
         )}
         <DividerWrapper orientation="vertical" variant="middle" flexItem />
         <NotificationTypes />
+        <DividerWrapper orientation="vertical" variant="middle" flexItem />
+        <ContentTypes />
         <DividerWrapper orientation="vertical" variant="middle" flexItem />
         <Box
           aria-label={t('common:action.delete')}

--- a/packages/frontend/src/components/Editor/SlateToolbar.tsx
+++ b/packages/frontend/src/components/Editor/SlateToolbar.tsx
@@ -79,7 +79,7 @@ export const SlateToolbar = () => {
   };
 
   return (
-    <Slate editor={editor} value={value} onChange={() => {}}>
+    <Slate editor={editor} value={value}>
       <ToolbarPaperWrapper elevation={2} aria-label={t('common:edit.toolbar')}>
         <ToggleButtonGroupWrapper size="small">
           {BlockButton({

--- a/packages/frontend/src/contexts/EditorContext.tsx
+++ b/packages/frontend/src/contexts/EditorContext.tsx
@@ -10,6 +10,7 @@ import { getRouterName } from '../utils/helpers';
 import { isSlateValueEmpty, openNotification } from '../utils/slateEditorUtil';
 import { ElementType } from '../utils/types';
 import withLinks from '../plugins/withLinks';
+import { createParagraphNode } from '../utils/createSlateNode';
 
 export const createEditorWithPlugins = pipe(withReact, withLinks);
 
@@ -21,7 +22,7 @@ export const EditorContext = React.createContext({
 });
 
 export type TSlateNode = { children: { text?: string; children?: any }[]; type?: string };
-const nodeTemplate: TSlateNode[] = [{ children: [{ text: '' }] }];
+export const nodeTemplate: TSlateNode[] = [createParagraphNode()];
 
 export const EditorContextProvider = (props: any) => {
   const { pathname } = useLocation();
@@ -43,9 +44,7 @@ export const EditorContextProvider = (props: any) => {
 
   const getNotificationData = () => {
     if (data && data.fields && !isEmpty(data.fields)) {
-      return data.fields.filter((field: any) => {
-        return field.type ? field.type.indexOf('notification') !== -1 : field;
-      });
+      return data.fields;
     }
     return nodeTemplate;
   };

--- a/packages/frontend/src/i18n.ts
+++ b/packages/frontend/src/i18n.ts
@@ -27,3 +27,5 @@ i18next.use(initReactI18next).init({
   resources,
   defaultNS,
 });
+
+export default i18next;

--- a/packages/frontend/src/pages/ProtectedPage/index.tsx
+++ b/packages/frontend/src/pages/ProtectedPage/index.tsx
@@ -30,9 +30,9 @@ export const ProtectedPage = ({ children }: Props) => {
     <ContainerWrapper>
       <NavBar />
       <ContentWrapper openedit={openEdit} opentoolbar={openToolbar}>
-        {isEditorOpened && <SlateInputField />}
         {isEditorOpened && <FileUploadDialogButton categoryName={categoryRouteName} />}
         {children}
+        {isEditorOpened && <SlateInputField />}
         {categoryRouteName && <CategoryFiles />}
         <Footer />
       </ContentWrapper>

--- a/packages/frontend/src/plugins/withLinks.ts
+++ b/packages/frontend/src/plugins/withLinks.ts
@@ -1,5 +1,4 @@
-import { ILinkElement } from '../utils/slateEditorUtil';
-import { ElementType } from '../utils/types';
+import { ElementType, ILinkElement } from '../utils/types';
 
 const withLinks = (editor: any) => {
   const { isInline } = editor;

--- a/packages/frontend/src/utils/createSlateNode.tsx
+++ b/packages/frontend/src/utils/createSlateNode.tsx
@@ -1,10 +1,20 @@
 import { Colors } from '../constants/Colors';
 import { ElementType, ILinkElement } from './types';
 
+export const createParagraphNode = () => ({
+  type: ElementType.PARAGRAPH_TWO,
+  children: [{ text: '' }],
+});
+
 export const createLinkNode = (href: string, text: string): ILinkElement => ({
   type: ElementType.LINK,
   href,
   children: [{ text }],
+});
+
+export const createNotificationNode = (notificationType: string) => ({
+  type: notificationType || ElementType.NOTIFICATION_INFO,
+  children: [{ text: '' }],
 });
 
 export const createContactCardNode = () => ({

--- a/packages/frontend/src/utils/createSlateNode.tsx
+++ b/packages/frontend/src/utils/createSlateNode.tsx
@@ -1,0 +1,68 @@
+import { Colors } from '../constants/Colors';
+import { ElementType, ILinkElement } from './types';
+
+export const createLinkNode = (href: string, text: string): ILinkElement => ({
+  type: ElementType.LINK,
+  href,
+  children: [{ text }],
+});
+
+export const createContactCardNode = () => ({
+  type: ElementType.CARD,
+  children: [
+    {
+      children: [{ type: ElementType.CARD_TITLE, children: [{ text: 'Yhteystiedot' }] }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'Vastuullisuus 1', bold: true }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'Henkilö nimi 1' }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'Puhelin numero 1' }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'test1@example.com', color: Colors.midblue }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'Vastuullisuus 2', bold: true }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'Henkilö nimi 2' }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'Puhelin numero 2' }],
+    },
+    {
+      children: [{ text: '' }],
+    },
+    {
+      children: [{ text: 'test2@example.com', color: Colors.midblue }],
+    },
+  ],
+});

--- a/packages/frontend/src/utils/createSlateNode.tsx
+++ b/packages/frontend/src/utils/createSlateNode.tsx
@@ -1,3 +1,5 @@
+import i18n from '../i18n';
+
 import { Colors } from '../constants/Colors';
 import { ElementType, ILinkElement } from './types';
 
@@ -17,62 +19,64 @@ export const createNotificationNode = (notificationType: string) => ({
   children: [{ text: '' }],
 });
 
-export const createContactCardNode = () => ({
-  type: ElementType.CARD,
-  children: [
-    {
-      children: [{ type: ElementType.CARD_TITLE, children: [{ text: 'Yhteystiedot' }] }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'Vastuullisuus 1', bold: true }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'Henkilö nimi 1' }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'Puhelin numero 1' }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'test1@example.com', color: Colors.midblue }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'Vastuullisuus 2', bold: true }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'Henkilö nimi 2' }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'Puhelin numero 2' }],
-    },
-    {
-      children: [{ text: '' }],
-    },
-    {
-      children: [{ text: 'test2@example.com', color: Colors.midblue }],
-    },
-  ],
-});
+export const createContactCardNode = () => {
+  return {
+    type: ElementType.CARD,
+    children: [
+      {
+        children: [{ type: ElementType.CARD_TITLE, children: [{ text: i18n.t('common:card.contact_information') }] }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.responsibility'), bold: true }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.name') }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.phone_number') }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.email'), color: Colors.midblue }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.responsibility'), bold: true }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.name') }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.phone_number') }],
+      },
+      {
+        children: [{ text: '' }],
+      },
+      {
+        children: [{ text: i18n.t('common:card.email'), color: Colors.midblue }],
+      },
+    ],
+  };
+};

--- a/packages/frontend/src/utils/slateEditorUtil.tsx
+++ b/packages/frontend/src/utils/slateEditorUtil.tsx
@@ -1,52 +1,29 @@
 import { Node, Editor, Element, Transforms, Path, Range } from 'slate';
 import { ReactEditor } from 'slate-react';
+
+import { ContactEditorCard } from '../components/Editor/Cards/ContactEditorCard';
 import { NotificationEditorCard } from '../components/Editor/Cards/NotificationEditorCard';
 import { LinkPopup } from '../components/Editor/Popup/LinkPopup';
+import { HighlightedTitle } from '../components/Typography/HighlightedTitle';
 import { TSlateNode } from '../contexts/EditorContext';
+import { createContactCardNode, createLinkNode } from './createSlateNode';
 
-import { ElementType, FontFormatType, IElement } from './types';
-
-interface IParagraphElement extends IElement {
-  type: ElementType.PARAGRAPH_ONE | ElementType.PARAGRAPH_TWO;
-  children: any;
-}
-
-interface IHeadingElement extends IElement {
-  type: ElementType.HEADING_ONE | ElementType.HEADING_TWO;
-  level: number;
-  children: any;
-}
-
-interface IListElement extends IElement {
-  type: ElementType.LIST_ITEM | ElementType.BULLET_LIST | ElementType.NUMBERED_LIST;
-  children: any;
-}
-
-export interface ILinkElement extends IElement {
-  type: ElementType.LINK;
-  href: string;
-  children: any;
-}
-
-export interface INotificationElement extends IElement {
-  type:
-    | ElementType.NOTIFICATION_INFO
-    | ElementType.NOTIFICATION_WARNING
-    | ElementType.NOTIFICATION_ERROR
-    | ElementType.NOTIFICATION_CONFIRMATION;
-}
+import {
+  ElementType,
+  FontFormatType,
+  ICardElement,
+  IHeadingElement,
+  ILinkElement,
+  IListElement,
+  INotificationElement,
+  IParagraphElement,
+} from './types';
 
 export type SlateElementProps = {
   attributes: any;
   children: any;
-  element: IParagraphElement | IHeadingElement | IListElement | ILinkElement | INotificationElement;
+  element: IParagraphElement | IHeadingElement | IListElement | ILinkElement | INotificationElement | ICardElement;
 };
-
-const createLinkNode = (href: string, text: string): ILinkElement => ({
-  type: ElementType.LINK,
-  href,
-  children: [{ text }],
-});
 
 export const SlateElement = ({ attributes, children, element }: SlateElementProps) => {
   switch (element.type) {
@@ -75,6 +52,10 @@ export const SlateElement = ({ attributes, children, element }: SlateElementProp
       return <ol {...attributes}>{children}</ol>;
     case ElementType.LINK:
       return <LinkPopup attributes={attributes} children={children} element={element} />;
+    case ElementType.CARD_TITLE:
+      return <HighlightedTitle {...attributes}>{children}</HighlightedTitle>;
+    case ElementType.CARD:
+      return <ContactEditorCard attributes={attributes} children={children} element={element} />;
     case ElementType.PARAGRAPH_ONE:
       return (
         <span {...attributes} style={{ fontSize: '18px' }}>
@@ -230,7 +211,7 @@ export const openNotification = (editor: any, format: ElementType) => {
 
   if (isNotification) {
     const block = { type: format, children: [] };
-    Transforms.wrapNodes(editor, block);
+    Transforms.insertNodes(editor, block, { at: [0] });
   }
 };
 

--- a/packages/frontend/src/utils/slateEditorUtil.tsx
+++ b/packages/frontend/src/utils/slateEditorUtil.tsx
@@ -6,7 +6,7 @@ import { NotificationEditorCard } from '../components/Editor/Cards/NotificationE
 import { LinkPopup } from '../components/Editor/Popup/LinkPopup';
 import { HighlightedTitle } from '../components/Typography/HighlightedTitle';
 import { TSlateNode } from '../contexts/EditorContext';
-import { createContactCardNode, createLinkNode } from './createSlateNode';
+import { createContactCardNode, createLinkNode, createNotificationNode, createParagraphNode } from './createSlateNode';
 
 import {
   ElementType,
@@ -210,25 +210,34 @@ export const openNotification = (editor: any, format: ElementType) => {
   });
 
   if (isNotification) {
-    const block = { type: format, children: [] };
-    Transforms.insertNodes(editor, block, { at: [0] });
+    Transforms.insertNodes(editor, createNotificationNode(format), { at: [0] });
   }
 };
 
-export const deleteNotification = (editor: any, format: ElementType, shouldDeleteEditor?: boolean) => {
-  const isActive = isBlockActive(editor, format);
-  if (isActive) {
-    Transforms.unwrapNodes(editor, {
-      match: (n: Node) =>
-        (n as any).type === ElementType.NOTIFICATION_INFO ||
-        (n as any).type === ElementType.NOTIFICATION_WARNING ||
-        (n as any).type === ElementType.NOTIFICATION_ERROR ||
-        (n as any).type === ElementType.NOTIFICATION_CONFIRMATION,
-      split: true,
-    });
-    if (shouldDeleteEditor) {
-      deleteEditor(editor);
-    }
+export const openText = (editor: any, format: ElementType) => {
+  Transforms.select(editor, Editor.end(editor, []));
+  ReactEditor.focus(editor);
+
+  const isText = format === ElementType.PARAGRAPH_TWO || format === ElementType.PARAGRAPH_ONE;
+  if (isText) {
+    const text = createParagraphNode();
+    Transforms.insertNodes(editor, text, { at: Editor.end(editor, []) });
+  }
+};
+
+export const openContactCard = (editor: any, format: ElementType) => {
+  Transforms.select(editor, Editor.end(editor, []));
+  ReactEditor.focus(editor);
+
+  const isCard = format === ElementType.CARD;
+
+  Transforms.unwrapNodes(editor, {
+    match: (n: Node) => (n as any).type === ElementType.CARD,
+    split: true,
+  });
+  if (isCard) {
+    const block = createContactCardNode();
+    Transforms.insertNodes(editor, block, { at: [editor.children.length - 1] });
   }
 };
 

--- a/packages/frontend/src/utils/slateEditorUtil.tsx
+++ b/packages/frontend/src/utils/slateEditorUtil.tsx
@@ -191,14 +191,16 @@ export const insertLink = (editor: any, url: string) => {
 };
 
 export const openNotification = (editor: any, format: ElementType) => {
-  Transforms.select(editor, Editor.end(editor, []));
-  ReactEditor.focus(editor);
-
   const isNotification =
     format === ElementType.NOTIFICATION_INFO ||
     format === ElementType.NOTIFICATION_WARNING ||
     format === ElementType.NOTIFICATION_ERROR ||
     format === ElementType.NOTIFICATION_CONFIRMATION;
+
+  if (!format || !isNotification) return;
+
+  Transforms.select(editor, Editor.end(editor, []));
+  ReactEditor.focus(editor);
 
   Transforms.unwrapNodes(editor, {
     match: (n: Node) =>
@@ -209,36 +211,32 @@ export const openNotification = (editor: any, format: ElementType) => {
     split: true,
   });
 
-  if (isNotification) {
-    Transforms.insertNodes(editor, createNotificationNode(format), { at: [0] });
-  }
+  Transforms.insertNodes(editor, createNotificationNode(format), { at: Editor.start(editor, []) });
 };
 
-export const openText = (editor: any, format: ElementType) => {
+export const insertParagraph = (editor: any, format: ElementType) => {
+  const isText = format === ElementType.PARAGRAPH_TWO || format === ElementType.PARAGRAPH_ONE;
+  if (!format || !isText) return;
   Transforms.select(editor, Editor.end(editor, []));
   ReactEditor.focus(editor);
 
-  const isText = format === ElementType.PARAGRAPH_TWO || format === ElementType.PARAGRAPH_ONE;
-  if (isText) {
-    const text = createParagraphNode();
-    Transforms.insertNodes(editor, text, { at: Editor.end(editor, []) });
-  }
+  const text = createParagraphNode();
+  Transforms.insertNodes(editor, text, { at: Editor.end(editor, []) });
 };
 
 export const openContactCard = (editor: any, format: ElementType) => {
+  const isCard = format === ElementType.CARD;
+  if (!format || !isCard) return;
+
   Transforms.select(editor, Editor.end(editor, []));
   ReactEditor.focus(editor);
-
-  const isCard = format === ElementType.CARD;
 
   Transforms.unwrapNodes(editor, {
     match: (n: Node) => (n as any).type === ElementType.CARD,
     split: true,
   });
-  if (isCard) {
-    const block = createContactCardNode();
-    Transforms.insertNodes(editor, block, { at: [editor.children.length - 1] });
-  }
+  const card = createContactCardNode();
+  Transforms.insertNodes(editor, card, { at: [editor.children.length - 1] });
 };
 
 export const deleteEditor = (editor: any) => {

--- a/packages/frontend/src/utils/types.ts
+++ b/packages/frontend/src/utils/types.ts
@@ -32,7 +32,7 @@ export interface IParagraphElement extends IElement {
 }
 
 export interface IHeadingElement extends IElement {
-  type: ElementType.HEADING_ONE | ElementType.HEADING_TWO | ElementType.CARD_TITLE;
+  type: ElementType.HEADING_ONE | ElementType.HEADING_TWO;
   level: number;
   children: any;
 }
@@ -57,5 +57,5 @@ export interface INotificationElement extends IElement {
 }
 
 export interface ICardElement extends IElement {
-  type: ElementType.CARD;
+  type: ElementType.CARD | ElementType.CARD_TITLE;
 }

--- a/packages/frontend/src/utils/types.ts
+++ b/packages/frontend/src/utils/types.ts
@@ -18,8 +18,44 @@ export enum ElementType {
   NOTIFICATION_WARNING = 'notification_warning',
   NOTIFICATION_ERROR = 'notification_error',
   NOTIFICATION_CONFIRMATION = 'notification_confirmation',
+  CARD_TITLE = 'card_title',
+  CARD = 'card',
 }
 
 export interface IElement {
   type: ElementType;
+}
+
+export interface IParagraphElement extends IElement {
+  type: ElementType.PARAGRAPH_ONE | ElementType.PARAGRAPH_TWO;
+  children: any;
+}
+
+export interface IHeadingElement extends IElement {
+  type: ElementType.HEADING_ONE | ElementType.HEADING_TWO | ElementType.CARD_TITLE;
+  level: number;
+  children: any;
+}
+
+export interface IListElement extends IElement {
+  type: ElementType.LIST_ITEM | ElementType.BULLET_LIST | ElementType.NUMBERED_LIST;
+  children: any;
+}
+
+export interface ILinkElement extends IElement {
+  type: ElementType.LINK;
+  href: string;
+  children: any;
+}
+
+export interface INotificationElement extends IElement {
+  type:
+    | ElementType.NOTIFICATION_INFO
+    | ElementType.NOTIFICATION_WARNING
+    | ElementType.NOTIFICATION_ERROR
+    | ElementType.NOTIFICATION_CONFIRMATION;
+}
+
+export interface ICardElement extends IElement {
+  type: ElementType.CARD;
 }


### PR DESCRIPTION
**DONE:**
- Insert new paragraph and contact card template in editor (currently use only one editor for notification, card and texts)
- Can save and fetch editor data from database
- Remove "delete" button in toolbar cause it doesn't work (temporarily), user manually deletes with backspace

**Edit mode**
![Screenshot 2023-04-20 at 18 45 12](https://user-images.githubusercontent.com/31354481/233418705-f30c391c-8faf-4ad3-b52c-2f09ccab537b.png)

**View mode**
![Screenshot 2023-04-20 at 18 43 30](https://user-images.githubusercontent.com/31354481/233418502-5e9c95e3-af58-4b7c-abdc-52b20bd776ed.png)

**TODO:**
- Notification doesn't work properly
- Add back "delete" button
- isEditorOpened should be autofocus in beginning
- Fix unit and cypress 
