### PR TITLE
feat/RTENU-192-filelist-endpoint

### DIFF
--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -261,6 +261,12 @@ export class RataExtraBackendStack extends NestedStack {
       relativePath: '../packages/server/lambdas/alfresco/list-components.ts',
     });
 
+    const getNodesById = this.createNodejsLambda({
+      ...prismaAlfrescoCombinedParameters,
+      name: 'get-nodes',
+      relativePath: '../packages/server/lambdas/alfresco/list-nodes.ts',
+    });
+
     const dbGetPageContents = this.createNodejsLambda({
       ...prismaParameters,
       name: 'db-get-page-contents',
@@ -355,11 +361,11 @@ export class RataExtraBackendStack extends NestedStack {
         targetName: 'alfrescoDeleteFolder',
       },
       {
-        lambda: getComponents,
-        priority: 145,
-        path: ['/api/alfresco/folder/*'],
+        lambda: getNodesById,
+        priority: 144,
+        path: ['/api/alfresco/nodes/*'],
         httpRequestMethods: ['GET'],
-        targetName: 'getComponents',
+        targetName: 'getNodesById',
       },
       {
         lambda: dbGetPageContents,
@@ -381,6 +387,13 @@ export class RataExtraBackendStack extends NestedStack {
         path: ['/api/database/user-right'],
         httpRequestMethods: ['GET'],
         targetName: 'checkUserRightOnPageContents',
+      },
+      {
+        lambda: getComponents,
+        priority: 220,
+        path: ['/api/database/components/*'],
+        httpRequestMethods: ['GET'],
+        targetName: 'getComponents',
       },
     ];
     // ALB for API

--- a/packages/server/lambdas/alfresco/list-nodes.ts
+++ b/packages/server/lambdas/alfresco/list-nodes.ts
@@ -1,0 +1,59 @@
+import { ALBEvent, ALBResult } from 'aws-lambda';
+import axios from 'axios';
+import { getAlfrescoUrlBase } from '../../utils/alfresco';
+
+import { getRataExtraLambdaError, RataExtraLambdaError } from '../../utils/errors';
+import { log } from '../../utils/logger';
+import { getUser, validateReadUser } from '../../utils/userService';
+
+const getNodes = async (id: string, type?: string) => {
+  const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
+  try {
+    let queryParameter = '';
+    if (type && type === 'folder') {
+      queryParameter = `?where=(isFolder=true)`;
+    }
+    if (type && type === 'file') {
+      queryParameter = `?where=(isFile=true)`;
+    }
+    return await axios.get(`${alfrescoCoreAPIUrl}/nodes/${id}/children${queryParameter}`);
+  } catch (error) {
+    return error;
+  }
+};
+
+/**
+ * Get the list of files or folders by given ID. Example: /api/alfresco/nodes/abc-123?type=folder
+ * @param {ALBEvent} event
+ * @param {{id: string, type?: NodeType }} event.queryStringParameters
+ * @returns {Promise<ALBResult>} List of nodes for given ID
+ */
+export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
+  try {
+    const paths = event.path.split('/');
+    const nodeId = paths.pop();
+    const user = await getUser(event);
+    const params = event.queryStringParameters;
+    const type = params?.type;
+
+    log.info(user, `Getting nodes for id ${nodeId} `);
+
+    validateReadUser(user);
+    if (!nodeId) {
+      throw new RataExtraLambdaError('node ID missing', 400);
+    }
+
+    const categoryData = await getNodes(nodeId, type);
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(categoryData),
+    };
+  } catch (err) {
+    log.error(err);
+    return getRataExtraLambdaError(err);
+  }
+}


### PR DESCRIPTION
- add endpoint for listing nodes (files or folders) by ID

`GET api/alfresco/{ID}?type=folder/file`

- refactor getComponents lambda
  - change path from /alfresco to /database
  - change priority number to be more accurate and not in scope of /alfresco reserved numbers