### PR TITLE
Hotfix/RTENU-224 category subfolders listing

### DIFF
--- a/packages/frontend/src/components/Files/CategoryFiles.tsx
+++ b/packages/frontend/src/components/Files/CategoryFiles.tsx
@@ -16,10 +16,11 @@ import { getCategoryRouteName } from '../../routes';
 import { MenuContext } from '../../contexts/MenuContext';
 
 type TCategoryFilesProps = {
-  subCategory?: string;
+  childFolderName?: string;
+  nestedFolderId?: string;
 };
 
-export const CategoryFiles = ({ subCategory }: TCategoryFilesProps) => {
+export const CategoryFiles = ({ childFolderName, nestedFolderId }: TCategoryFilesProps) => {
   const { t } = useTranslation(['common', 'search']);
   const location = useLocation();
   const [fileList, setFileList] = useState<TNode[]>([]);
@@ -40,8 +41,11 @@ export const CategoryFiles = ({ subCategory }: TCategoryFilesProps) => {
   const getCategoryFiles = useCallback(async () => {
     try {
       setLoading(true);
-      const subCategoryQuery = subCategory ? `&folderid=${subCategory}` : '';
-      const response = await axios.get(`/api/alfresco/files?category=${categoryName}${subCategoryQuery}&page=${page}`);
+      const childFolderNameQuery = childFolderName ? `&childFolderName=${childFolderName}` : '';
+      const nestedFolderIdQuery = nestedFolderId ? `&nestedFolderId=${nestedFolderId}` : '';
+      const response = await axios.get(
+        `/api/alfresco/files?category=${categoryName}${childFolderNameQuery}${nestedFolderIdQuery}&page=${page}`,
+      );
       const { data, hasClassifiedContent } = response.data;
       const totalFiles = get(data, 'list.entries', []);
       const totalItems = get(data, 'list.pagination.totalItems', 0);

--- a/packages/frontend/src/components/Files/CategoryFiles.tsx
+++ b/packages/frontend/src/components/Files/CategoryFiles.tsx
@@ -40,7 +40,7 @@ export const CategoryFiles = ({ subCategory }: TCategoryFilesProps) => {
   const getCategoryFiles = useCallback(async () => {
     try {
       setLoading(true);
-      const subCategoryQuery = subCategory ? `&subcategory=${subCategory}` : '';
+      const subCategoryQuery = subCategory ? `&folderid=${subCategory}` : '';
       const response = await axios.get(`/api/alfresco/files?category=${categoryName}${subCategoryQuery}&page=${page}`);
       const { data, hasClassifiedContent } = response.data;
       const totalFiles = get(data, 'list.entries', []);

--- a/packages/frontend/src/components/Files/File.tsx
+++ b/packages/frontend/src/components/Files/File.tsx
@@ -136,7 +136,7 @@ export const NodeItem = ({
         )}
       </Grid>
       <Collapse key={`${name}-Collapse`} in={folderOpen} timeout="auto" unmountOnExit>
-        <CategoryFiles subCategory={name} />
+        <CategoryFiles subCategory={id} />
       </Collapse>
     </>
   );

--- a/packages/frontend/src/components/Files/File.tsx
+++ b/packages/frontend/src/components/Files/File.tsx
@@ -136,7 +136,7 @@ export const NodeItem = ({
         )}
       </Grid>
       <Collapse key={`${name}-Collapse`} in={folderOpen} timeout="auto" unmountOnExit>
-        <CategoryFiles subCategory={id} />
+        <CategoryFiles nestedFolderId={id} />
       </Collapse>
     </>
   );

--- a/packages/frontend/src/pages/ProtectedPage/ProtectedSubPage.tsx
+++ b/packages/frontend/src/pages/ProtectedPage/ProtectedSubPage.tsx
@@ -30,7 +30,7 @@ export const ProtectedSubPage = ({ children }: Props) => {
         <DesktopAppBar />
         <ContentWrapper openedit={openEdit} opentoolbar={openToolbar}>
           {children}
-          {categoryRouteName && <CategoryFiles subCategory={area} />}
+          {categoryRouteName && <CategoryFiles childFolderName={area} />}
         </ContentWrapper>
         <Footer />
       </Box>

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -48,7 +48,7 @@ const searchByTermWithParent = async (uid: string, alfrescoParent: string, page:
     const alfrescoSearchAPIUrl = `${getAlfrescoUrlBase()}/search/versions/1/search`;
     const options = await getAlfrescoOptions(uid, { 'Content-Type': 'application/json;charset=UTF-8' });
     log.info(alfrescoSearchAPIUrl, 'alfrescoSearchAPIUrl');
-    log.info(`bodyRequest ${bodyRequest} is stringified`);
+    log.info(bodyRequest, 'bodyRequest');
     const response = await axios.post(`${alfrescoSearchAPIUrl}`, bodyRequest, options);
     return response.data;
   } catch (err) {
@@ -65,8 +65,9 @@ const getFolder = async (uid: string, nodeId: string) => {
     return response.data;
   } catch (error: any) {
     log.info(`Error ${JSON.stringify(error)} is stringified`);
+    log.info(`${error.status} or ${error.statusCode} is error status`);
     // In case nodeId doesn't exist, Alfresco throws 404
-    if (error.err && (error.err.status === 404 || error.err.statusCode === 404)) {
+    if (error.status === 404 || error.statusCode === 404) {
       return null;
     } else {
       throw error;

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -59,13 +59,13 @@ const getFolder = async (uid: string, nodeId: string) => {
   try {
     const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
     const url = `${alfrescoCoreAPIUrl}/nodes/${nodeId}?where=(isFolder=true)&include=path`;
-    log.info(url, ' is Axios URL');
     const options = await getAlfrescoOptions(uid, { 'Content-Type': 'application/json;charset=UTF-8' });
-    log.info(options, ' is Axios options');
     const response = await axios.get(url, options);
     return response.data;
-  } catch (err) {
-    throw err;
+  } catch (error: any) {
+    log.error(error);
+    // In case nodeId doesn't exist, Alfresco throws 404
+    throw error;
   }
 };
 

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -63,9 +63,12 @@ const getFolder = async (uid: string, nodeId: string) => {
     const response = await axios.get(url, options);
     return response.data;
   } catch (error: any) {
-    log.error(error);
     // In case nodeId doesn't exist, Alfresco throws 404
-    throw error;
+    if (error.status === 404) {
+      return null;
+    } else {
+      throw error;
+    }
   }
 };
 
@@ -95,6 +98,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
     const category = params?.category;
     const folderId = params?.folderid;
     log.info(user, `Fetching files for for page ${category} with folder id ${folderId} `);
+    // Default response
     const responseBody = {
       hasClassifiedContent: true,
       data: {
@@ -110,7 +114,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
           entries: [],
         },
       },
-    }; // Default response
+    };
 
     validateReadUser(user);
     if (!category) {

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -47,7 +47,8 @@ const searchByTermWithParent = async (uid: string, alfrescoParent: string, page:
     });
     const alfrescoSearchAPIUrl = `${getAlfrescoUrlBase()}/search/versions/1/search`;
     const options = await getAlfrescoOptions(uid, { 'Content-Type': 'application/json;charset=UTF-8' });
-
+    log.info(alfrescoSearchAPIUrl, 'alfrescoSearchAPIUrl');
+    log.info(`bodyRequest ${bodyRequest} is stringified`);
     const response = await axios.post(`${alfrescoSearchAPIUrl}`, bodyRequest, options);
     return response.data;
   } catch (err) {
@@ -63,6 +64,7 @@ const getFolder = async (uid: string, nodeId: string) => {
     const response = await axios.get(url, options);
     return response.data;
   } catch (error: any) {
+    log.info(`Error ${JSON.stringify(error)} is stringified`);
     // In case nodeId doesn't exist, Alfresco throws 404
     if (error.err && (error.err.status === 404 || error.err.statusCode === 404)) {
       return null;

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -60,8 +60,10 @@ const searchByTermWithParent = async (uid: string, alfrescoParent: string, page:
 const getFolder = async (id: string) => {
   try {
     const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
-    const response = await axios.get(`${alfrescoCoreAPIUrl}/nodes/${id}?where=(isFolder=true)&include=path`);
-    return response.data;
+    const url = `${alfrescoCoreAPIUrl}/nodes/${id}?where=(isFolder=true)&include=path`;
+    log.info(url, ' is getFolder URL');
+    const response = await axios.get(url);
+    return response;
   } catch (err) {
     throw err;
   }
@@ -92,7 +94,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
     const params = event.queryStringParameters;
     const category = params?.category;
     const folderId = params?.folderid;
-    log.info(user, `Fetching files for for page ${category} with folder ${folderId} `);
+    log.info(user, `Fetching files for for page ${category} with folder id ${folderId} `);
     const responseBody = {
       hasClassifiedContent: true,
       data: {
@@ -134,6 +136,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
       responseBody.data = await searchByTermWithParent(user.uid, alfrescoParent, page, language);
     } else {
       const foundFolder = await getFolder(folderId);
+      log.info(foundFolder, ` is folder with id ${folderId}`);
       const folderPath = get(foundFolder, 'entry.path.name', '');
       const isFolderDescendantOfCategory = await isFolderInCategory(folderPath, category);
       if (isFolderDescendantOfCategory) {

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -1,6 +1,6 @@
 import { CategoryDataBase } from '@prisma/client';
 import { ALBEvent, ALBResult } from 'aws-lambda';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 import { getRataExtraLambdaError, RataExtraLambdaError } from '../../utils/errors';
 import { log } from '../../utils/logger';
@@ -65,10 +65,14 @@ const getFolder = async (uid: string, nodeId: string) => {
     return response.data;
   } catch (error: any) {
     log.info(`Error ${JSON.stringify(error)} is stringified`);
-    log.info(`${error.status} or ${error.statusCode} is error status`);
-    // In case nodeId doesn't exist, Alfresco throws 404
-    if (error.status === 404 || error.statusCode === 404) {
-      return null;
+    log.info(`${error.response} is supposed to contain error status`);
+    if (error instanceof AxiosError) {
+      // In case nodeId doesn't exist, Alfresco throws 404
+      if (error.response && error.response.status === 404) {
+        return null;
+      } else {
+        throw error;
+      }
     } else {
       throw error;
     }

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -10,6 +10,7 @@ import { DatabaseClient } from '../database/client';
 import { searchQueryBuilder } from './searchQueryBuilder';
 import {
   AdditionalFields,
+  IAncestorSearchParameter,
   IFolderSearchParameter,
   IParentSearchParameter,
   QueryLanguage,
@@ -31,13 +32,7 @@ export type TNode = {
   };
 };
 
-const searchByTermWithParent = async (
-  uid: string,
-  alfrescoParent: string,
-  alfrescoFolder = '',
-  page: number,
-  language: QueryLanguage,
-) => {
+const searchByTermWithParent = async (uid: string, alfrescoParent: string, page: number, language: QueryLanguage) => {
   try {
     const searchParameters = [];
     const parent: IParentSearchParameter = {
@@ -45,14 +40,6 @@ const searchByTermWithParent = async (
       parent: alfrescoParent,
     };
     searchParameters.push(parent);
-    if (alfrescoFolder) {
-      const folder: IFolderSearchParameter = {
-        parameterName: SearchParameterName.FOLDER,
-        name: alfrescoFolder,
-      };
-      searchParameters.push(folder);
-    }
-
     const bodyRequest = searchQueryBuilder({
       searchParameters: searchParameters,
       page: page,
@@ -70,12 +57,30 @@ const searchByTermWithParent = async (
   }
 };
 
+const getFolder = async (id: string) => {
+  try {
+    const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
+    const response = await axios.get(`${alfrescoCoreAPIUrl}/nodes/${id}?where=(isFolder=true)&include=path`);
+    return response.data;
+  } catch (err) {
+    throw err;
+  }
+};
+
+const isFolderInCategory = async (folderPath: string, category: string) => {
+  // Split the path into its components
+  const pathComponents = folderPath.split('/');
+
+  // Check if the parent folder name is among the path components
+  return pathComponents.includes(category);
+};
+
 const database = await DatabaseClient.build();
 
 let fileEndpointsCache: Array<CategoryDataBase> = [];
 
 /**
- * Get the list of files embedded to given page. Example: /api/alfresco/files?category=linjakaaviot&subcategory=kansio_nimi
+ * Get the list of files embedded to given page. Example: /api/alfresco/files?category=linjakaaviot&folderid=123
  * @param {ALBEvent} event
  * @param {{category: string, page?: number, language?: QueryLanguage }} event.queryStringParameters
  * @param {string} event.queryStringParameters.category Page to be searched for
@@ -86,15 +91,31 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
     const user = await getUser(event);
     const params = event.queryStringParameters;
     const category = params?.category;
-    const subCategory = params?.subcategory ? decodeURI(params?.subcategory) : params?.subcategory;
-    log.info(user, `Fetching files for for page ${category} with folder ${subCategory} `);
+    const folderId = params?.folderid;
+    log.info(user, `Fetching files for for page ${category} with folder ${folderId} `);
+    const responseBody = {
+      hasClassifiedContent: true,
+      data: {
+        list: {
+          pagination: {
+            count: 0,
+            hasMoreItems: false,
+            totalItems: 0,
+            skipCount: 0,
+            maxItems: 25,
+          },
+          context: {},
+          entries: [],
+        },
+      },
+    }; // Default response
 
     validateReadUser(user);
     if (!category) {
       throw new RataExtraLambdaError('Category missing', 400);
     }
     const page = params?.page ? parseInt(params?.page) : 0;
-    const categoryPage = subCategory ? 0 : page;
+    const categoryPage = folderId ? 0 : page;
     const language = (params?.language as QueryLanguage) ?? QueryLanguage.LUCENE;
     if (!Object.values(QueryLanguage).includes(language)) {
       throw new RataExtraLambdaError('Invalid language', 400);
@@ -104,23 +125,20 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
     }
     const endpoint = findEndpoint(category, fileEndpointsCache);
     const alfrescoParent = endpoint?.alfrescoFolder;
-    const hasClassifiedContent = endpoint?.hasClassifiedContent;
+    responseBody.hasClassifiedContent = endpoint?.hasClassifiedContent || true;
 
     if (!alfrescoParent) {
       throw new RataExtraLambdaError('Category not found', 404);
     }
-
-    const categoryData = await searchByTermWithParent(user.uid, alfrescoParent, subCategory, categoryPage, language);
-    if (subCategory) {
-      const folderId = get(categoryData, 'list.entries[0].entry.id', -1);
-      const subCategoryData = await searchByTermWithParent(user.uid, folderId, '', page, language);
-      return {
-        statusCode: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ data: subCategoryData, hasClassifiedContent }),
-      };
+    if (!folderId) {
+      responseBody.data = await searchByTermWithParent(user.uid, alfrescoParent, page, language);
+    } else {
+      const foundFolder = await getFolder(folderId);
+      const folderPath = get(foundFolder, 'entry.path.name', '');
+      const isFolderDescendantOfCategory = await isFolderInCategory(folderPath, category);
+      if (isFolderDescendantOfCategory) {
+        responseBody.data = await searchByTermWithParent(user.uid, folderId, categoryPage, language);
+      }
     }
 
     return {
@@ -128,7 +146,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ data: categoryData, hasClassifiedContent }),
+      body: JSON.stringify(responseBody),
     };
   } catch (err) {
     log.error(err);

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -63,11 +63,12 @@ const getFolder = async (uid: string, nodeId: string) => {
     const response = await axios.get(url, options);
     return response.data;
   } catch (error: any) {
+    log.info('Error: ', error);
     // In case nodeId doesn't exist, Alfresco throws 404
     if (error.status === 404) {
       return null;
     } else {
-      throw error;
+      return null;
     }
   }
 };

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -63,9 +63,8 @@ const getFolder = async (uid: string, nodeId: string) => {
     const response = await axios.get(url, options);
     return response.data;
   } catch (error: any) {
-    log.info(error, 'Error');
     // In case nodeId doesn't exist, Alfresco throws 404
-    if (error.status === 404 || error.statusCode === 404) {
+    if (error.err && (error.err.status === 404 || error.err.statusCode === 404)) {
       return null;
     } else {
       throw error;

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -91,7 +91,9 @@ const isFolderInCategory = async (folderPath: string, category: string) => {
   const pathComponents = folderPath.split('/');
 
   // Check if the parent folder name is among the path components
-  return pathComponents.includes(category);
+  // Adjust the index based on given path structure
+  // e.g. /Company Home/Sites/ratat-extra/documentLibrary/hallintaraportit -> ['', 'Company Home', 'Sites', 'ratat-extra', 'documentLibrary', 'hallintaraportit']
+  return pathComponents[6] === category;
 };
 
 const database = await DatabaseClient.build();

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -124,7 +124,6 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
       throw new RataExtraLambdaError('Category missing', 400);
     }
     const page = params?.page ? parseInt(params?.page) : 0;
-    const categoryPage = folderId ? 0 : page;
     const language = (params?.language as QueryLanguage) ?? QueryLanguage.LUCENE;
     if (!Object.values(QueryLanguage).includes(language)) {
       throw new RataExtraLambdaError('Invalid language', 400);
@@ -146,7 +145,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
       const folderPath = get(foundFolder, 'entry.path.name', '');
       const isFolderDescendantOfCategory = await isFolderInCategory(folderPath, category);
       if (isFolderDescendantOfCategory) {
-        responseBody.data = await searchByTermWithParent(user.uid, folderId, categoryPage, language);
+        responseBody.data = await searchByTermWithParent(user.uid, folderId, page, language);
       }
     }
 

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -118,7 +118,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
     const user = await getUser(event);
     const params = event.queryStringParameters;
     // only listed parameters are accepted
-    validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName']);
+    validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName', 'page', 'language']);
     const category = params?.category;
     const nestedFolderId = params?.nestedFolderId;
     const childFolderName = params?.childFolderName;

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -93,7 +93,7 @@ const isFolderInCategory = async (folderPath: string, category: string) => {
   // Check if the parent folder name is among the path components
   // Adjust the index based on given path structure
   // e.g. /Company Home/Sites/ratat-extra/documentLibrary/hallintaraportit -> ['', 'Company Home', 'Sites', 'ratat-extra', 'documentLibrary', 'hallintaraportit']
-  return pathComponents[6] === category;
+  return pathComponents[5] === category;
 };
 
 const database = await DatabaseClient.build();
@@ -165,7 +165,10 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
     }
 
     if (childFolderName) {
-      data = await searchByTermWithParent(user.uid, alfrescoParent, childFolderName, page, language); // direct child folder name is given
+      // Check if the folder is a direct child of the category
+      const childFolder = await searchByTermWithParent(user.uid, alfrescoParent, childFolderName, page, language); // direct child folder name is given
+      const childFolderId = get(childFolder, 'list.entries[0].entry.id', -1);
+      data = await searchByTermWithParent(user.uid, childFolderId, '', page, language);
     }
 
     if (!nestedFolderId && !childFolderName) {

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -63,12 +63,12 @@ const getFolder = async (uid: string, nodeId: string) => {
     const response = await axios.get(url, options);
     return response.data;
   } catch (error: any) {
-    log.info('Error: ', error);
+    log.info(error, 'Error');
     // In case nodeId doesn't exist, Alfresco throws 404
-    if (error.status === 404) {
+    if (error.status === 404 || error.statusCode === 404) {
       return null;
     } else {
-      return null;
+      throw error;
     }
   }
 };
@@ -141,7 +141,6 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
       responseBody.data = await searchByTermWithParent(user.uid, alfrescoParent, page, language);
     } else {
       const foundFolder = await getFolder(user.uid, folderId);
-      log.info(foundFolder, ` is folder with id ${folderId}`);
       const folderPath = get(foundFolder, 'entry.path.name', '');
       const isFolderDescendantOfCategory = await isFolderInCategory(folderPath, category);
       if (isFolderDescendantOfCategory) {

--- a/packages/server/lambdas/alfresco/list-files.ts
+++ b/packages/server/lambdas/alfresco/list-files.ts
@@ -17,6 +17,7 @@ import {
   SortingFieldParameter,
 } from './searchQueryBuilder/types';
 import { get } from 'lodash';
+import { validateQueryParameters } from '../../utils/validation';
 
 export type TNode = {
   entry: {
@@ -116,6 +117,8 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
   try {
     const user = await getUser(event);
     const params = event.queryStringParameters;
+    // only listed parameters are accepted
+    validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName']);
     const category = params?.category;
     const nestedFolderId = params?.nestedFolderId;
     const childFolderName = params?.childFolderName;

--- a/packages/server/lambdas/database/check-user-right.ts
+++ b/packages/server/lambdas/database/check-user-right.ts
@@ -5,6 +5,7 @@ import { findEndpoint } from '../../utils/alfresco';
 import { getRataExtraLambdaError, RataExtraLambdaError } from '../../utils/errors';
 import { log } from '../../utils/logger';
 import { getUser, validateReadUser, validateWriteUser } from '../../utils/userService';
+import { validateQueryParameters } from '../../utils/validation';
 import { DatabaseClient } from './client';
 
 const database = await DatabaseClient.build();
@@ -25,6 +26,8 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult> {
 
   try {
     const params = event.queryStringParameters;
+    // only listed parameters are accepted
+    validateQueryParameters(params, ['category']);
     const category = params?.category;
 
     const user = await getUser(event);

--- a/packages/server/utils/__tests__/validation.test.ts
+++ b/packages/server/utils/__tests__/validation.test.ts
@@ -1,0 +1,53 @@
+import { validateQueryParameters } from '../validation';
+
+describe('validateQueryParameters', () => {
+  it('should pass with correct parameters', () => {
+    const params: Record<string, unknown> = {
+      category: 'testCategory',
+      nestedFolderId: 'testNestedFolderId',
+      childFolderName: 'testChildFolderName',
+    };
+
+    expect(() => validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName'])).not.toThrow();
+  });
+
+  it('should pass with missing expected parameters', () => {
+    const params: Record<string, unknown> = {
+      category: 'testCategory',
+      nestedFolderId: 'testNestedFolderId',
+      // childFolderName is missing
+    };
+
+    expect(() => validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName'])).not.toThrow();
+  });
+
+  it('should pass with empty parameters', () => {
+    const params: Record<string, unknown> = {};
+
+    expect(() => validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName'])).not.toThrow();
+  });
+
+  it('should fail with extra parameters', () => {
+    const params: Record<string, unknown> = {
+      category: 'testCategory',
+      nestedFolderId: 'testNestedFolderId',
+      childFolderName: 'testChildFolderName',
+      extraParam: 'extraParam',
+    };
+
+    expect(() => validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName'])).toThrow(
+      'Unexpected query parameter: extraParam.  Only valid parameters are: category, nestedFolderId, childFolderName',
+    );
+  });
+
+  it('should fail with missing expected parameters and one extra parameter', () => {
+    const params: Record<string, unknown> = {
+      category: 'testCategory',
+      extraParam: 'extraParam',
+    };
+
+    expect(() => validateQueryParameters(params, ['category', 'nestedFolderId', 'childFolderName'])).toThrow(
+      'Unexpected query parameter: extraParam.  Only valid parameters are: category, nestedFolderId, childFolderName',
+    );
+  });
+});

--- a/packages/server/utils/validation.ts
+++ b/packages/server/utils/validation.ts
@@ -1,0 +1,23 @@
+import { RataExtraLambdaError } from './errors';
+
+/**
+ * Validates if there are any unexpected query parameters in the request.
+ * @param {Record<string, unknown>} queryParams - Actual query parameters from the request.
+ * @param {Array<string>} expectedParams - List of expected query parameters.
+ * @throws {RataExtraLambdaError} If unexpected query parameters are found.
+ */
+export function validateQueryParameters(
+  queryParams: Record<string, unknown> = {},
+  expectedParams: Array<string>,
+): void {
+  const actualParams = Object.keys(queryParams);
+
+  actualParams.forEach((param) => {
+    if (!expectedParams.includes(param)) {
+      throw new RataExtraLambdaError(
+        `Unexpected query parameter: ${param}.  Only valid parameters are: ${expectedParams.join(', ')}`,
+        400,
+      );
+    }
+  });
+}


### PR DESCRIPTION
- Replace `subcategory` folder name with `nestedFolderId` or `childFolderName`  to avoid possible duplicated names and is still based on main category name
- Validate and throw error if receive invalid parameter names
- Endpoints:
1. Case 1: Get the list of files and folders embedded to category page.
- Example: /api/alfresco/files?category=linjakaaviot
2. Case 2: Get the list of files and folders embedded to any folder that is a descendant of category page.
- Example: /api/alfresco/files?category=linjakaaviot&nestedFolderId=123
3. Case 3: Get the list of files and folders embedded to direct child folder of category page
- Example: /api/alfresco/files?category=linjakaaviot&childFolderName=vuosi_2023

<img width="717" alt="Screenshot 2023-05-22 at 17 39 54" src="https://github.com/finnishtransportagency/ratatiedot-extranet/assets/31354481/522c5099-c0c1-4d7e-b6aa-0edeea0442aa">
