### PR TITLE
fix/RTENU-233-search-query

### DIFF
--- a/packages/frontend/src/components/Search/index.tsx
+++ b/packages/frontend/src/components/Search/index.tsx
@@ -116,7 +116,7 @@ export const Search = ({ isDesktop = false }: SearchProps) => {
         />
       </>
       {openSearch && !openFilter && <RecentSearch exitSearch={exitSearch} />}
-      <FilterSearch filtersApplied={() => {}} />
+      <FilterSearch filtersApplied={() => search()} />
     </>
   );
 };

--- a/packages/frontend/src/contexts/SearchContext.tsx
+++ b/packages/frontend/src/contexts/SearchContext.tsx
@@ -44,14 +44,6 @@ export const SearchContextProvider = (props: any) => {
 
   useEffect(() => {
     queryHandler(searchParams.get('query') || '');
-    sortHandler('');
-    yearsHandler(null, null);
-    savedCheckboxesHandler({
-      [SearchParameterName.MIME]: [],
-      [SearchParameterName.CATEGORY]: [],
-    });
-    pageHandler(0);
-    contentSearchHandler(false);
   }, [searchParams]);
 
   const queryHandler = (query: string) => {


### PR DESCRIPTION
- Remove handlers that would reset filters every time when navigating to /search page or submitting new query
- Use previously defined function to be triggered when applying filters