### PR TITLE
Fix/pdf upload

### DIFF
--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -16,7 +16,9 @@ const base64ToBuffer = (base64string: string): Buffer => {
 };
 
 const bufferToBlob = (buffer: Buffer) => {
+  devLog.debug('buffer: ' + JSON.stringify(buffer));
   const blob = new Blob([buffer]);
+  devLog.debug('blob: ' + JSON.stringify(blob));
   return blob;
 };
 
@@ -24,6 +26,7 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
   devLog.debug('requestFormData' + JSON.stringify(requestFormData));
   const formData = new FormData();
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
+  devLog.debug('fileData: ' + JSON.stringify(fileData));
   const fileInfo = requestFormData.fileinfo as FileInfo;
   formData.append('filedata', fileData, fileInfo.filename);
   formData.append('name', fileInfo.filename);

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -21,7 +21,7 @@ const bufferToBlob = (buffer: Buffer) => {
 };
 
 const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
-  devLog.debug('requestFormData' + requestFormData);
+  devLog.debug('requestFormData' + JSON.stringify(requestFormData));
   const formData = new FormData();
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
   const fileInfo = requestFormData.fileinfo as FileInfo;
@@ -33,8 +33,8 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
 
 export class AlfrescoFileRequestBuilder {
   public async requestBuilder(event: ALBEvent, headers: HeadersInit) {
-    devLog.debug('event' + event);
-    devLog.debug('headers' + headers);
+    devLog.debug('event' + JSON.stringify(event));
+    devLog.debug('headers' + JSON.stringify(headers));
     if (event.isBase64Encoded) {
       event.body = base64ToString(event.body as string);
     }

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -3,33 +3,26 @@ import { ParsedFormDataOptions, parseForm } from '../../../utils/parser';
 import { ALBEvent, ALBEventHeaders } from 'aws-lambda';
 import { Blob } from 'buffer';
 import { FileInfo } from 'busboy';
-import { devLog } from '../../../utils/logger';
 
+// Keeping this function here until file upload is confirmed to work in production
 // const base64ToString = (base64string: string): string => {
 //   const buffer = Buffer.from(base64string, 'base64').toString('utf-8').replace(/\r?\n/g, '\r\n');
-//   devLog.debug('buffer: ' + JSON.stringify(buffer));
 //   return buffer;
 // };
 
 const base64ToBuffer = (base64string: string): Buffer => {
-  devLog.debug('base64ToBuffer: ', base64string);
   const buffer = Buffer.from(base64string, 'base64');
-  devLog.debug('buffer: ' + buffer);
   return buffer;
 };
 
 const bufferToBlob = (buffer: Buffer) => {
-  devLog.debug('buffer: ' + JSON.stringify(buffer));
   const blob = new Blob([buffer]);
-  devLog.debug('blob: ' + JSON.stringify(blob));
   return blob;
 };
 
 const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
-  devLog.debug('requestFormData' + JSON.stringify(requestFormData));
   const formData = new FormData();
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
-  devLog.debug('fileData: ' + JSON.stringify(fileData));
   const fileInfo = requestFormData.fileinfo as FileInfo;
   formData.append('filedata', fileData, fileInfo.filename);
   formData.append('name', fileInfo.filename);
@@ -39,12 +32,9 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
 
 export class AlfrescoFileRequestBuilder {
   public async requestBuilder(event: ALBEvent, headers: ALBEventHeaders) {
-    devLog.debug('event' + JSON.stringify(event));
-    devLog.debug('headers' + JSON.stringify(headers));
     const body = event.body ?? '';
     let buffer;
     if (event.isBase64Encoded) {
-      devLog.debug('event.body: ' + JSON.stringify(event.body));
       buffer = base64ToBuffer(event.body as string);
     }
     const options = {

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -21,7 +21,7 @@ const bufferToBlob = (buffer: Buffer) => {
 };
 
 const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
-  devLog.debug('requestFormData', requestFormData);
+  devLog.debug('requestFormData' + requestFormData);
   const formData = new FormData();
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
   const fileInfo = requestFormData.fileinfo as FileInfo;
@@ -33,8 +33,8 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
 
 export class AlfrescoFileRequestBuilder {
   public async requestBuilder(event: ALBEvent, headers: HeadersInit) {
-    devLog.debug('event', event);
-    devLog.debug('headers', headers);
+    devLog.debug('event' + event);
+    devLog.debug('headers' + headers);
     if (event.isBase64Encoded) {
       event.body = base64ToString(event.body as string);
     }

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -3,6 +3,7 @@ import { ParsedFormDataOptions, parseForm } from '../../../utils/parser';
 import { ALBEvent } from 'aws-lambda';
 import { Blob } from 'buffer';
 import { FileInfo } from 'busboy';
+import { devLog } from '../../../utils/logger';
 
 const base64ToString = (base64string: string): string => {
   const buffer = Buffer.from(base64string, 'base64').toString('utf-8').replace(/\r?\n/g, '\r\n');
@@ -20,6 +21,7 @@ const bufferToBlob = (buffer: Buffer) => {
 };
 
 const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
+  devLog.debug('requestFormData', requestFormData);
   const formData = new FormData();
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
   const fileInfo = requestFormData.fileinfo as FileInfo;
@@ -31,6 +33,8 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
 
 export class AlfrescoFileRequestBuilder {
   public async requestBuilder(event: ALBEvent, headers: HeadersInit) {
+    devLog.debug('event', event);
+    devLog.debug('headers', headers);
     if (event.isBase64Encoded) {
       event.body = base64ToString(event.body as string);
     }

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -49,7 +49,7 @@ export class AlfrescoFileRequestBuilder {
     }
     const options = {
       method: 'POST',
-      body: createForm(await parseForm(buffer ?? body, headers)),
+      body: createForm(await parseForm(buffer ?? body, event.headers as ALBEventHeaders)),
       headers: headers,
     } as RequestInit;
     return options;

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -7,6 +7,7 @@ import { devLog } from '../../../utils/logger';
 
 const base64ToString = (base64string: string): string => {
   const buffer = Buffer.from(base64string, 'base64').toString('utf-8').replace(/\r?\n/g, '\r\n');
+  devLog.debug('buffer: ' + JSON.stringify(buffer));
   return buffer;
 };
 
@@ -39,6 +40,7 @@ export class AlfrescoFileRequestBuilder {
     devLog.debug('event' + JSON.stringify(event));
     devLog.debug('headers' + JSON.stringify(headers));
     if (event.isBase64Encoded) {
+      devLog.debug('event.body: ' + JSON.stringify(event.body));
       event.body = base64ToString(event.body as string);
     }
     const options = {

--- a/packages/server/lambdas/alfresco/upload-file.ts
+++ b/packages/server/lambdas/alfresco/upload-file.ts
@@ -18,13 +18,9 @@ let fileEndpointsCache: Array<CategoryDataBase> = [];
 const postFile = async (options: RequestInit, nodeId: string): Promise<AlfrescoResponse | undefined> => {
   const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
   const url = `${alfrescoCoreAPIUrl}/nodes/${nodeId}/children`;
-  try {
-    const res = await fetch(url, options);
-    const result = (await res.json()) as AlfrescoResponse;
-    return result;
-  } catch (err) {
-    console.error('error:' + err);
-  }
+  const res = await fetch(url, options);
+  const result = (await res.json()) as AlfrescoResponse;
+  return result;
 };
 
 /**

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -1,7 +1,6 @@
 import { ALBEventHeaders } from 'aws-lambda';
 import busboy, { FileInfo } from 'busboy';
 import { Readable } from 'stream';
-import { devLog } from './logger';
 
 export interface ParsedFormDataOptions {
   [key: string]: string | Buffer | Readable | FileInfo;
@@ -35,7 +34,6 @@ export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => 
         temp.fileinfo = fileinfo as FileInfo;
 
         form = { ...temp };
-        devLog.debug('form: ' + form);
         console.log('File parse finished');
       });
     });

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -1,4 +1,4 @@
-import { ALBEvent } from 'aws-lambda';
+import { ALBEventHeaders } from 'aws-lambda';
 import busboy, { FileInfo } from 'busboy';
 import { Readable } from 'stream';
 
@@ -6,10 +6,10 @@ export interface ParsedFormDataOptions {
   [key: string]: string | Buffer | Readable | FileInfo;
 }
 
-export const parseForm = (event: ALBEvent) => {
+export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => {
   return new Promise<ParsedFormDataOptions>((resolve, reject) => {
     const form = {} as ParsedFormDataOptions;
-    const bb = busboy({ headers: event.headers });
+    const bb = busboy({ headers: headers });
 
     bb.on('file', (fieldname: string, file: Readable, fileinfo: FileInfo) => {
       form.fieldname = fieldname;
@@ -31,6 +31,6 @@ export const parseForm = (event: ALBEvent) => {
       reject(err);
     });
 
-    bb.end(event.body);
+    bb.end(buffer);
   });
 };

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -1,26 +1,43 @@
 import { ALBEventHeaders } from 'aws-lambda';
 import busboy, { FileInfo } from 'busboy';
 import { Readable } from 'stream';
+import { devLog } from './logger';
 
 export interface ParsedFormDataOptions {
   [key: string]: string | Buffer | Readable | FileInfo;
 }
 
+interface FormData {
+  fieldname: string;
+  fileinfo?: FileInfo;
+  file: any;
+}
+
 export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => {
   return new Promise<ParsedFormDataOptions>((resolve, reject) => {
-    const form = {} as ParsedFormDataOptions;
-    const bb = busboy({ headers: headers });
+    const bb = busboy({
+      headers: {
+        ...headers,
+        'content-type': headers['Content-Type'] || headers['content-type'],
+      },
+    });
+    let form = {} as ParsedFormDataOptions;
 
     bb.on('file', (fieldname: string, file: Readable, fileinfo: FileInfo) => {
-      form.fieldname = fieldname;
-      form.file = file;
-      form.fileinfo = fileinfo as FileInfo;
-
+      const temp: FormData = { file: [], fieldname: '' };
       file.on('data', (data: Buffer) => {
-        form[fieldname] = data;
+        temp.file.push(data);
       });
 
-      file.on('end', () => console.log('File parse finished'));
+      file.on('end', () => {
+        temp.file = Buffer.concat(temp.file);
+        temp.fieldname = fieldname;
+        temp.fileinfo = fileinfo as FileInfo;
+
+        form = { ...temp };
+        devLog.debug('form: ' + form);
+        console.log('File parse finished');
+      });
     });
 
     bb.on('finish', () => {


### PR DESCRIPTION
- Replace unnecessary string conversion with Buffer
- Instead of assigning data in parse function directly to form, push the data to Buffer array and concat it at the end.
  - This was the issue that caused too large file uploads to fail


🗒️ This PR fixes file upload to support <1MB files. We are still looking what might cause >1MB file upload to fail.