### PR TITLE
Hotfix/RTENU-256 broken uploaded file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap": "npx lerna bootstrap --force-local",
     "build": "npx lerna run build",
     "build:frontend": "npm --prefix packages/frontend run build",
-    "ci": "npx lerna bootstrap --ci",
+    "ci": "npm ci",
     "dev-client": "cd packages/frontend && npm start",
     "dev-server": "cd packages/server && npm start",
     "dev": "concurrently \"npm run dev-server\" \"npm run dev-client\"",

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -40,7 +40,7 @@ export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => 
         form = {
           ...form,
           fieldname,
-          file: Buffer.concat(chunks),
+          filedata: Buffer.concat(chunks),
           fileinfo: fileInfo,
         };
         console.log('File parse finished');

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -7,12 +7,6 @@ export interface ParsedFormDataOptions {
   [key: string]: string | Buffer | Readable | FileInfo;
 }
 
-// interface FormData {
-//   fieldname: string;
-//   fileinfo?: FileInfo;
-//   file: any;
-// }
-
 export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => {
   return new Promise<ParsedFormDataOptions>((resolve, reject) => {
     const bb = busboy({
@@ -24,10 +18,6 @@ export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => 
     let form = {} as ParsedFormDataOptions;
 
     bb.on('file', (fieldname: string, file: Readable, fileinfo: FileInfo) => {
-      const { filename, encoding, mimeType } = fileinfo;
-      log.info('filename: ', filename);
-      log.info('encoding: ', encoding);
-      log.info('mimeType: ', mimeType);
       const chunks: Buffer[] = [];
       file.on('data', (data: Buffer) => {
         log.info(`Received ${data.length} bytes for field ${fieldname}`);
@@ -35,13 +25,12 @@ export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => 
       });
 
       file.on('end', () => {
-        const fileInfo: FileInfo = { filename, encoding, mimeType };
-        console.log(`Finished receiving file for field ${fieldname}, total size: ${chunks.length} bytes`);
+        log.info(`Finished receiving file for field ${fieldname}, total size: ${chunks.length} bytes`);
         form = {
           ...form,
           fieldname,
           filedata: Buffer.concat(chunks),
-          fileinfo: fileInfo,
+          fileinfo,
         };
         console.log('File parse finished');
       });

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -20,19 +20,19 @@ export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => 
     bb.on('file', (fieldname: string, file: Readable, fileinfo: FileInfo) => {
       const chunks: Buffer[] = [];
       file.on('data', (data: Buffer) => {
-        log.info(`Received ${data.length} bytes for field ${fieldname}`);
+        log.debug(`Received ${data.length} bytes for field ${fieldname}`);
         chunks.push(data);
       });
 
       file.on('end', () => {
-        log.info(`Finished receiving file for field ${fieldname}, total size: ${chunks.length} bytes`);
+        log.debug(`Finished receiving file for field ${fieldname}, total size: ${chunks.length} bytes`);
         form = {
           ...form,
           fieldname,
           filedata: Buffer.concat(chunks),
           fileinfo,
         };
-        console.log('File parse finished');
+        log.info('File parse finished');
       });
     });
 


### PR DESCRIPTION
- Replacing `file` with `filedata` in `parseForm()` seems to work (`createForm()` uses `requestFormData.filedata`)
- Small refactor: remove `tempt`  and assign data directly to `form`
- [Build failed](https://eu-west-1.console.aws.amazon.com/codesuite/codebuild/178238255639/projects/PipelineRataExtraPipelineBu-6RNeNEJ80FA6/build/PipelineRataExtraPipelineBu-6RNeNEJ80FA6%3A5a7dc355-550a-4938-ac39-d1a0d99823e9/?region=eu-west-1) with command "npx lerna bootstrap --ci", changing to `npm ci` fixes the issue:
![Screenshot 2023-06-08 at 19 40 44](https://github.com/finnishtransportagency/ratatiedot-extranet/assets/31354481/de292a8f-b5df-4542-ace1-85da74b10168)

