### PR TITLE
Hotfix/RTENU-256 upload larger file size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29698,6 +29698,7 @@
         "aws-lambda": "^1.0.7",
         "axios": "^1.1.3",
         "busboy": "^1.6.0",
+        "form-data": "^4.0.0",
         "formdata-node": "^5.0.0",
         "jsonwebtoken": "^8.5.1",
         "jwk-to-pem": "^2.0.5",
@@ -29721,6 +29722,19 @@
         "prisma": "^4.13.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
+      }
+    },
+    "packages/server/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "packages/server/node_modules/node-fetch": {
@@ -48984,6 +48998,7 @@
         "busboy": "^1.6.0",
         "chai": "^4.3.6",
         "chai-http": "^4.3.0",
+        "form-data": "^4.0.0",
         "formdata-node": "^5.0.0",
         "jsonwebtoken": "^8.5.1",
         "jwk-to-pem": "^2.0.5",
@@ -48995,6 +49010,16 @@
         "typescript": "^4.9.5"
       },
       "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
         "node-fetch": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -24,10 +24,7 @@ const bufferToBlob = (buffer: Buffer) => {
 
 const createForm = async (requestFormData: ParsedFormDataOptions): Promise<FormData> => {
   const formData = new FormData();
-  console.log('Before creating Blob: ', process.memoryUsage());
   const fileData: Blob = await bufferToBlob(requestFormData.filedata as Buffer);
-  console.log('After creating Blob: ', process.memoryUsage());
-  console.log('fileData: ', fileData);
   const fileInfo = (await requestFormData.fileinfo) as FileInfo;
   log.debug(`File data blob size: ${fileData.size}`);
   formData.append('filedata', fileData, fileInfo.filename);
@@ -44,13 +41,13 @@ export class AlfrescoFileRequestBuilder {
       buffer = base64ToBuffer(event.body as string);
     }
     const formData = await parseForm(buffer ?? body, event.headers as ALBEventHeaders);
-    console.log('formData: ', formData);
     const form = await createForm(formData);
     const options = {
       method: 'POST',
       body: form,
       headers: headers,
     } as RequestInit;
+    console.log('requestBuilder options: ', options);
     return options;
   }
   public async updateRequestBuilder(event: ALBEvent, headers: HeadersInit) {

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -17,7 +17,8 @@ const base64ToBuffer = (base64string: string): Buffer => {
 };
 
 const bufferToBlob = (buffer: Buffer) => {
-  const blob = new Blob([buffer]);
+  const unit8Array = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  const blob = new Blob([unit8Array]);
   return blob;
 };
 
@@ -26,6 +27,7 @@ const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
   console.log('fileData: ', fileData);
   const fileInfo = requestFormData.fileinfo as FileInfo;
+  log.debug(`File data blob size: ${fileData.size}`);
   formData.append('filedata', fileData, fileInfo.filename);
   formData.append('name', fileInfo.filename);
   formData.append('nodeType', 'cm:content');

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -22,11 +22,13 @@ const bufferToBlob = (buffer: Buffer) => {
   return blob;
 };
 
-const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
+const createForm = async (requestFormData: ParsedFormDataOptions): Promise<FormData> => {
   const formData = new FormData();
-  const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
+  console.log('Before creating Blob: ', process.memoryUsage());
+  const fileData: Blob = await bufferToBlob(requestFormData.filedata as Buffer);
+  console.log('After creating Blob: ', process.memoryUsage());
   console.log('fileData: ', fileData);
-  const fileInfo = requestFormData.fileinfo as FileInfo;
+  const fileInfo = (await requestFormData.fileinfo) as FileInfo;
   log.debug(`File data blob size: ${fileData.size}`);
   formData.append('filedata', fileData, fileInfo.filename);
   formData.append('name', fileInfo.filename);
@@ -43,7 +45,7 @@ export class AlfrescoFileRequestBuilder {
     }
     const formData = await parseForm(buffer ?? body, event.headers as ALBEventHeaders);
     console.log('formData: ', formData);
-    const form = createForm(formData);
+    const form = await createForm(formData);
     const options = {
       method: 'POST',
       body: form,

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -24,7 +24,7 @@ const bufferToBlob = (buffer: Buffer) => {
 const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
   const formData = new FormData();
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
-  log.debug(fileData);
+  console.log('fileData: ', fileData);
   const fileInfo = requestFormData.fileinfo as FileInfo;
   formData.append('filedata', fileData, fileInfo.filename);
   formData.append('name', fileInfo.filename);
@@ -39,9 +39,12 @@ export class AlfrescoFileRequestBuilder {
     if (event.isBase64Encoded) {
       buffer = base64ToBuffer(event.body as string);
     }
+    const formData = await parseForm(buffer ?? body, event.headers as ALBEventHeaders);
+    console.log('formData: ', formData);
+    const form = createForm(formData);
     const options = {
       method: 'POST',
-      body: createForm(await parseForm(buffer ?? body, event.headers as ALBEventHeaders)),
+      body: form,
       headers: headers,
     } as RequestInit;
     return options;

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -3,6 +3,7 @@ import { ParsedFormDataOptions, parseForm } from '../../../utils/parser';
 import { ALBEvent, ALBEventHeaders } from 'aws-lambda';
 import { Blob } from 'buffer';
 import { FileInfo } from 'busboy';
+import { log } from '../../../utils/logger';
 
 // Keeping this function here until file upload is confirmed to work in production
 // const base64ToString = (base64string: string): string => {
@@ -23,6 +24,7 @@ const bufferToBlob = (buffer: Buffer) => {
 const createForm = (requestFormData: ParsedFormDataOptions): FormData => {
   const formData = new FormData();
   const fileData: Blob = bufferToBlob(requestFormData.filedata as Buffer);
+  log.debug(fileData);
   const fileInfo = requestFormData.fileinfo as FileInfo;
   formData.append('filedata', fileData, fileInfo.filename);
   formData.append('name', fileInfo.filename);

--- a/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
+++ b/packages/server/lambdas/alfresco/fileRequestBuilder/alfrescoRequestBuilder.ts
@@ -4,6 +4,16 @@ import { ALBEvent, ALBEventHeaders } from 'aws-lambda';
 import { FileInfo } from 'busboy';
 import { log } from '../../../utils/logger';
 
+// Keeping these functions here until file upload is confirmed to work in production
+// const base64ToString = (base64string: string): string => {
+//   const buffer = Buffer.from(base64string, 'base64').toString('utf-8').replace(/\r?\n/g, '\r\n');
+//   return buffer;
+// };
+// const bufferToBlob = (buffer: Buffer) => {
+//   const blob = new Blob([buffer]);
+//   return blob;
+// };
+
 const base64ToBuffer = (base64string: string): Buffer => {
   const buffer = Buffer.from(base64string, 'base64');
   return buffer;

--- a/packages/server/lambdas/alfresco/upload-file.ts
+++ b/packages/server/lambdas/alfresco/upload-file.ts
@@ -19,7 +19,10 @@ const postFile = async (options: RequestInit, nodeId: string): Promise<AlfrescoR
   const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
   const url = `${alfrescoCoreAPIUrl}/nodes/${nodeId}/children`;
   console.log('URL:', url, ', options:', options);
-  return await alfrescoFetch(url, options);
+  return await alfrescoFetch(url, {
+    ...options,
+    highWaterMark: 1024 * 1024, // ~1MB
+  });
 };
 
 /**

--- a/packages/server/lambdas/alfresco/upload-file.ts
+++ b/packages/server/lambdas/alfresco/upload-file.ts
@@ -82,6 +82,7 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult | undefi
 
     const headers = (await getAlfrescoOptions(user.uid)).headers;
     const requestOptions = (await fileRequestBuilder(event, headers)) as RequestInit;
+    console.log('requestOptions: ', requestOptions);
     const result = await postFile(requestOptions, targetNode);
     auditLog.info(
       user,

--- a/packages/server/lambdas/alfresco/upload-file.ts
+++ b/packages/server/lambdas/alfresco/upload-file.ts
@@ -18,6 +18,7 @@ let fileEndpointsCache: Array<CategoryDataBase> = [];
 const postFile = async (options: RequestInit, nodeId: string): Promise<AlfrescoResponse | undefined> => {
   const alfrescoCoreAPIUrl = `${getAlfrescoUrlBase()}/alfresco/versions/1`;
   const url = `${alfrescoCoreAPIUrl}/nodes/${nodeId}/children`;
+  console.log('URL:', url, ', options:', options);
   return await alfrescoFetch(url, options);
 };
 
@@ -82,8 +83,18 @@ export async function handleRequest(event: ALBEvent): Promise<ALBResult | undefi
 
     const headers = (await getAlfrescoOptions(user.uid)).headers;
     const requestOptions = (await fileRequestBuilder(event, headers)) as RequestInit;
-    console.log('requestOptions: ', requestOptions);
+
+    /**
+     * TESTING LOGS START
+     */
+    console.log('Sending request with body:', requestOptions.body?.toString());
+
     const result = await postFile(requestOptions, targetNode);
+    console.log('Result: ', result);
+    /**
+     * TESTING LOGS END
+     */
+
     auditLog.info(
       user,
       `Uploaded file ${result?.entry.name} with id ${result?.entry.id} to ${categoryData.alfrescoFolder}`,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,7 @@
     "aws-lambda": "^1.0.7",
     "axios": "^1.1.3",
     "busboy": "^1.6.0",
+    "form-data": "^4.0.0",
     "formdata-node": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.5",

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -16,7 +16,7 @@ export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => 
       },
       limits: {
         files: 1,
-        fileSize: 1000000, // bytes = 1MB
+        // fileSize: 1000000, // bytes = 1MB
       },
     });
     let form = {} as ParsedFormDataOptions;

--- a/packages/server/utils/parser.ts
+++ b/packages/server/utils/parser.ts
@@ -49,7 +49,6 @@ export const parseForm = (buffer: Buffer | string, headers: ALBEventHeaders) => 
       reject(err);
     });
 
-    bb.write(buffer);
-    bb.end();
+    bb.end(buffer);
   });
 };


### PR DESCRIPTION
Attempt to fix "Invalid state: chunk ArrayBuffer is zero-length or detached" error, now can upload file size around 1MB
- Use `axios` and `form-data` instead of `node-fetch` and `formdata-node`, no need to convert Buffer to Blob anymore. Axios uses the `form-data` library under the hood when handling "multipart/form-data" in Node.js so it's more compatible.
- Close stream and clean buffers after use