### PR TITLE
fix vite env variable declaration

### DIFF
--- a/packages/frontend/src/components/Files/File.tsx
+++ b/packages/frontend/src/components/Files/File.tsx
@@ -56,7 +56,7 @@ export const NodeItem = ({
   const title = entry.properties?.['cm:title'];
   const contentMimeType = get(content, 'mimeType', '');
   const contentSizeInBytes = get(content, 'sizeInBytes', 0);
-  const { REACT_APP_ALFRESCO_DOWNLOAD_URL } = process.env;
+  const { REACT_APP_ALFRESCO_DOWNLOAD_URL } = import.meta.env;
   const { openEdit, openToolbar } = useContext(AppBarContext);
 
   const isEditOpen = openEdit || openToolbar;


### PR DESCRIPTION
Vite migration caused frontend to break in dev environment. `process.env` not supported by Vite.

[issue:](https://github.com/vitejs/vite/issues/1973)

> "process.env is removed by https://github.com/vitejs/vite/commit/8ad7ecd1029bdc0b47e55877db10ac630829c7e5, you can use import.meta.env instead"