### PR TITLE
Remove redundant useEffect

### DIFF
--- a/packages/frontend/src/components/Files/CategoryFiles.tsx
+++ b/packages/frontend/src/components/Files/CategoryFiles.tsx
@@ -72,11 +72,6 @@ export const CategoryFiles = ({ childFolderName, nestedFolderId }: TCategoryFile
   }, [categoryName, page]);
 
   useEffect(() => {
-    setPage(0); // Reset page to 0 for saving file in development
-    getCategoryFiles();
-  }, []);
-
-  useEffect(() => {
     getCategoryFiles();
   }, [page]);
 


### PR DESCRIPTION
useEffect will still fire twice when in development mode because of React Strict Mode, but should be fine when deployed.