### PR TITLE
Correct id for alfresco content

### DIFF
--- a/packages/frontend/src/components/ActivityStream/ActivityItem.tsx
+++ b/packages/frontend/src/components/ActivityStream/ActivityItem.tsx
@@ -36,7 +36,7 @@ type NodeItemProps = {
 };
 
 export const ActivityItem = ({ node, row, isSelected = false }: NodeItemProps) => {
-  const { mimeType, fileName, timestamp, id, action } = node;
+  const { mimeType, fileName, timestamp, action, alfrescoId } = node;
   const { rataextraRequestPage } = node.categoryDataBase;
 
   const isFolder = mimeType === 'folder';
@@ -84,7 +84,7 @@ export const ActivityItem = ({ node, row, isSelected = false }: NodeItemProps) =
         }}
         href={
           isFile && !isDeleted
-            ? `${VITE_ALFRESCO_DOWNLOAD_URL}/alfresco/versions/1/nodes/${id}/content/${encodeURI(
+            ? `${VITE_ALFRESCO_DOWNLOAD_URL}/alfresco/versions/1/nodes/${alfrescoId}/content/${encodeURI(
                 fileName,
               )}?attachment=false`
             : undefined


### PR DESCRIPTION
Wrong id was used and redirection to alfresco to view the file didn't work.