### PR TITLE
upgrade node to version 18

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -46,6 +46,10 @@ const SSM_SONARQUBE_TOKEN = 'rataextra-sonarqube-token';
 const SSM_SERVICE_USER_UID = 'rataextra-service-user';
 const SSM_CLOUDFRONT_SIGNER_PUBLIC_KEY_ID = 'rataextra-cloudfront-signer-public-key-id';
 
+// Minified JS code that is used to make ES modules working
+// Also handles __dirname & import.meta.url
+export const ESM_REQUIRE_SHIM = `await(async()=>{let{dirname:e}=await import("path"),{fileURLToPath:i}=await import("url");if(typeof globalThis.__filename>"u"&&(globalThis.__filename=i(import.meta.url)),typeof globalThis.__dirname>"u"&&(globalThis.__dirname=e(globalThis.__filename)),typeof globalThis.require>"u"){let{default:a}=await import("module");globalThis.require=a.createRequire(import.meta.url)}})();`;
+
 function getStackId(branch: string): string {
   const stackId = getEnvOrFail('STACK_ID');
   if (branch === PRODUCTION_BRANCH && stackId !== PRODUCTION_STACK_ID) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -46,10 +46,6 @@ const SSM_SONARQUBE_TOKEN = 'rataextra-sonarqube-token';
 const SSM_SERVICE_USER_UID = 'rataextra-service-user';
 const SSM_CLOUDFRONT_SIGNER_PUBLIC_KEY_ID = 'rataextra-cloudfront-signer-public-key-id';
 
-// Minified JS code that is used to make ES modules working
-// Also handles __dirname & import.meta.url
-export const ESM_REQUIRE_SHIM = `await(async()=>{let{dirname:e}=await import("path"),{fileURLToPath:i}=await import("url");if(typeof globalThis.__filename>"u"&&(globalThis.__filename=i(import.meta.url)),typeof globalThis.__dirname>"u"&&(globalThis.__dirname=e(globalThis.__filename)),typeof globalThis.require>"u"){let{default:a}=await import("module");globalThis.require=a.createRequire(import.meta.url)}})();`;
-
 function getStackId(branch: string): string {
   const stackId = getEnvOrFail('STACK_ID');
   if (branch === PRODUCTION_BRANCH && stackId !== PRODUCTION_STACK_ID) {

--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -3,7 +3,13 @@ import { IVpc, ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Role, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LambdaTarget } from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
 import { Construct } from 'constructs';
-import { RataExtraEnvironment, SSM_DATABASE_DOMAIN, SSM_DATABASE_NAME, SSM_DATABASE_PASSWORD } from './config';
+import {
+  RataExtraEnvironment,
+  SSM_DATABASE_DOMAIN,
+  SSM_DATABASE_NAME,
+  SSM_DATABASE_PASSWORD,
+  ESM_REQUIRE_SHIM,
+} from './config';
 import { NodejsFunction, BundlingOptions, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { ListenerAction, ListenerCondition } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
@@ -148,6 +154,7 @@ export class RataExtraBackendStack extends NestedStack {
         esbuildArgs: {
           '--conditions': 'module',
         },
+        banner: ESM_REQUIRE_SHIM, // Workaround for ESM problem. https://github.com/evanw/esbuild/pull/2067#issuecomment-1073039746
         commandHooks: {
           beforeInstall(inputDir: string, outputDir: string) {
             return [`cp -R ${inputDir}/packages/server/prisma ${outputDir}/`];

--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -3,13 +3,7 @@ import { IVpc, ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Role, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LambdaTarget } from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
 import { Construct } from 'constructs';
-import {
-  RataExtraEnvironment,
-  SSM_DATABASE_DOMAIN,
-  SSM_DATABASE_NAME,
-  SSM_DATABASE_PASSWORD,
-  ESM_REQUIRE_SHIM,
-} from './config';
+import { RataExtraEnvironment, SSM_DATABASE_DOMAIN, SSM_DATABASE_NAME, SSM_DATABASE_PASSWORD } from './config';
 import { NodejsFunction, BundlingOptions, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { ListenerAction, ListenerCondition } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
@@ -154,7 +148,6 @@ export class RataExtraBackendStack extends NestedStack {
         esbuildArgs: {
           '--conditions': 'module',
         },
-        banner: ESM_REQUIRE_SHIM, // Workaround for ESM problem. https://github.com/evanw/esbuild/pull/2067#issuecomment-1073039746
         commandHooks: {
           beforeInstall(inputDir: string, outputDir: string) {
             return [`cp -R ${inputDir}/packages/server/prisma ${outputDir}/`];

--- a/lib/rataextra-backend.ts
+++ b/lib/rataextra-backend.ts
@@ -149,7 +149,7 @@ export class RataExtraBackendStack extends NestedStack {
       bundling: {
         nodeModules: ['prisma', '@prisma/client'],
         format: OutputFormat.ESM,
-        target: 'node16',
+        target: 'node18',
         mainFields: ['module', 'main'],
         esbuildArgs: {
           '--conditions': 'module',
@@ -612,7 +612,7 @@ export class RataExtraBackendStack extends NestedStack {
     securityGroups,
     memorySize = 1024,
     timeout = Duration.seconds(30),
-    runtime = Runtime.NODEJS_16_X,
+    runtime = Runtime.NODEJS_18_X,
     logRetention = RetentionDays.SIX_MONTHS,
     handler = 'handleRequest',
     environment = {},

--- a/packages/server/utils/parameterStore.ts
+++ b/packages/server/utils/parameterStore.ts
@@ -1,8 +1,7 @@
-// TODO: Figure out how to use import for this in a way that actually works
-const AWS = require('aws-sdk'); //eslint-disable-line @typescript-eslint/no-var-requires
+import { SSM } from 'aws-sdk';
 import { log } from './logger';
 
-const ssm = new AWS.SSM({ region: process.env.region || 'eu-west-1' });
+const ssm = new SSM({ region: process.env.region || 'eu-west-1' });
 
 export const getSecuredStringParameter = async (name: string) => {
   try {

--- a/packages/server/utils/validateJwtToken.ts
+++ b/packages/server/utils/validateJwtToken.ts
@@ -1,8 +1,7 @@
 import JWT, { JwtPayload } from 'jsonwebtoken';
 import Axios from 'axios';
 import { log } from './logger';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const jwkToPem = require('jwk-to-pem');
+import jwkToPem from 'jwk-to-pem';
 
 let cachedKeys: Record<string, string>;
 


### PR DESCRIPTION
- update nodejs version from 16 to 18
  - affected areas are lambda bundling and runtime
- convert requires to imports