### PR TITLE
Pin and upgrade axios to 1.13.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33969,7 +33969,7 @@
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.2",
         "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.12.0",
+        "axios": "1.13.5",
         "chalk": "^4.1.0",
         "cli-cursor": "3.1.0",
         "cli-spinners": "2.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/server"
       ],
       "dependencies": {
-        "axios": "1.13.5",
+        "axios": "1.13.6",
         "date-fns": "^2.30.0",
         "lodash": "4.17.23"
       },
@@ -9343,9 +9343,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -28502,9 +28502,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "requires": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -33969,7 +33969,7 @@
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.2",
         "@zkochan/js-yaml": "0.0.7",
-        "axios": "1.13.5",
+        "axios": "1.13.6",
         "chalk": "^4.1.0",
         "cli-cursor": "3.1.0",
         "cli-spinners": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/finnishtransportagency/ratatiedot-extranet#readme",
   "dependencies": {
-    "axios": "1.13.5",
+    "axios": "1.13.6",
     "date-fns": "^2.30.0",
     "lodash": "4.17.23"
   },
   "overrides": {
-    "axios": "1.13.5"
+    "axios": "1.13.6"
   },
   "devDependencies": {
     "@types/lodash": "4.17.23",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "date-fns": "^2.30.0",
     "lodash": "4.17.23"
   },
+  "overrides": {
+    "axios": "1.13.5"
+  },
   "devDependencies": {
     "@types/lodash": "4.17.23",
     "@types/node": "^22.19.7",

--- a/packages/node-server/package-lock.json
+++ b/packages/node-server/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-ssm": "3.993.0",
         "@prisma/adapter-pg": "7.3.0",
         "@prisma/client": "7.3.0",
-        "axios": "1.13.5",
+        "axios": "1.13.6",
         "busboy": "^1.6.0",
         "express": "^4.22.1",
         "form-data": "4.0.5",
@@ -1776,9 +1776,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -5944,9 +5944,9 @@
       "devOptional": true
     },
     "axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "requires": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -25,6 +25,9 @@
     "multer": "2.1.1",
     "pino": "10.3.1"
   },
+  "overrides": {
+    "axios": "1.13.5"
+  },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/multer": "2.0.0",

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -16,7 +16,7 @@
     "@aws-sdk/client-ssm": "3.993.0",
     "@prisma/adapter-pg": "7.3.0",
     "@prisma/client": "7.3.0",
-    "axios": "1.13.5",
+    "axios": "1.13.6",
     "busboy": "^1.6.0",
     "express": "^4.22.1",
     "form-data": "4.0.5",
@@ -26,7 +26,7 @@
     "pino": "10.3.1"
   },
   "overrides": {
-    "axios": "1.13.5"
+    "axios": "1.13.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",


### PR DESCRIPTION
Added override for axios version, to reduce risk of nested dependencies pulling a compromised version.