### PR TITLE
Feat/RTENU-518: six digit balise files

### DIFF
--- a/packages/frontend/src/modules/balise/pages/BaliseListPage/VirtualBaliseTable.tsx
+++ b/packages/frontend/src/modules/balise/pages/BaliseListPage/VirtualBaliseTable.tsx
@@ -571,7 +571,7 @@ export const VirtualBaliseTable: React.FC<BaliseTableProps> = ({
               <TableRow>
                 <TableCell colSpan={8} sx={{ textAlign: 'center', p: 2 }}>
                   <Typography variant="body2" color="text.secondary">
-                    Kaikki kohteet ladattu ({items.length} / {totalCount})
+                    Kaikki kohteet haettu ({items.length} / {totalCount})
                   </Typography>
                 </TableCell>
               </TableRow>

--- a/packages/frontend/src/modules/balise/pages/BulkUploadPage/BulkUploadPage.tsx
+++ b/packages/frontend/src/modules/balise/pages/BulkUploadPage/BulkUploadPage.tsx
@@ -258,7 +258,7 @@ export const BulkUploadPage: React.FC = () => {
 
   const handleUpload = async () => {
     if (validFileCount === 0) {
-      setLocalError('Ei ladattavia tiedostoja');
+      setLocalError('Ei lisättäviä tiedostoja');
       return;
     }
 
@@ -399,7 +399,7 @@ export const BulkUploadPage: React.FC = () => {
                     Erä {batchProgress.currentBatch} / {batchProgress.totalBatches}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
-                    Tiedostoja ladattu: {batchProgress.filesUploaded} / {batchProgress.totalFiles}
+                    Tiedostoja lisätty: {batchProgress.filesUploaded} / {batchProgress.totalFiles}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
                     Baliisit: {batchProgress.successCount} onnistui
@@ -723,7 +723,7 @@ export const BulkUploadPage: React.FC = () => {
                     {isSummaryMode && (
                       <Box sx={{ py: 2 }}>
                         <Typography variant="body1" sx={{ mb: 2 }}>
-                          Yhteenveto ladattavista baliiseista:
+                          Yhteenveto lisättävistä baliiseista:
                         </Typography>
                         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                           {newBaliseCount > 0 && (

--- a/packages/frontend/src/modules/balise/pages/BulkUploadPage/BulkUploadPage.tsx
+++ b/packages/frontend/src/modules/balise/pages/BulkUploadPage/BulkUploadPage.tsx
@@ -605,7 +605,7 @@ export const BulkUploadPage: React.FC = () => {
                       Tiedostojen nimet määrittävät baliisin: esim. <strong>10000.il</strong> → baliisi 10000
                     </Typography>
                     <Typography variant="caption" color="text.disabled">
-                      Tuetut tiedostot: .il, .leu, .bis, .pdf, .xlsx ja muut
+                      Tuetut tiedostot: .il, .leu, .bis
                     </Typography>
                   </label>
                 </Paper>

--- a/packages/frontend/src/modules/balise/utils/baliseValidation.ts
+++ b/packages/frontend/src/modules/balise/utils/baliseValidation.ts
@@ -46,31 +46,33 @@ export function isValidBaliseIdRange(baliseId: number): boolean {
 
 /**
  * Parse balise ID from filename
- * Only allows format: {ID}.ext or {ID}K.ext (K suffix only, case insensitive)
+ * Allows format: {5-digit ID}.ext, {5-digit ID}K.ext, or {5-digit ID}{digit}.ext
+ * The suffix can be K/k or a single digit 0-9 (case insensitive for K)
  * Examples:
  *   "10000.il" → 10000
  *   "10000.leu" → 10000
  *   "12345.bis" → 12345
  *   "10000K.il" → 10000
  *   "10000k.LEU" → 10000
- *   "10000X.il" → null (invalid - only K allowed)
+ *   "100034.il" → 10003
+ *   "100030.il" → 10003
+ *   "10000X.il" → null (invalid - only K or digit allowed)
  */
 export function parseBaliseIdFromFilename(filename: string): number | null {
-  // Match: digits, optionally followed by K/k, then a dot and extension
-  // This ensures only K suffix is allowed after the ID
-  const match = filename.match(/^(\d+)[Kk]?\.(il|leu|bis)$/i);
+  // Match: exactly 5 digits (the ID), optionally followed by K/k or a single digit, then a dot and extension
+  const match = filename.match(/^(\d{5})[Kk\d]?\.(il|leu|bis)$/i);
   if (!match) return null;
   const id = parseInt(match[1], 10);
   return isNaN(id) ? null : id;
 }
 
 /**
- * Check if filename has valid format (ID with optional K suffix + valid extension)
+ * Check if filename has valid format (5-digit ID with optional K or digit suffix + valid extension)
  * Returns false if there are invalid characters between ID and extension
  */
 export function isValidFilenameFormat(filename: string): boolean {
-  // Valid format: {digits}{optional K/k}.{il|leu|bis} (case insensitive for extension)
-  return /^(\d+)[Kk]?\.(il|leu|bis)$/i.test(filename);
+  // Valid format: {5 digits}{optional K/k or digit}.{il|leu|bis} (case insensitive for extension)
+  return /^(\d{5})[Kk\d]?\.(il|leu|bis)$/i.test(filename);
 }
 
 /**
@@ -101,7 +103,7 @@ export function validateBaliseFile(filename: string, targetBaliseId: number): Va
       errors.push(`Virheellinen tiedostopääte. Sallitut päätteet: ${getValidExtensionsList()}`);
     } else {
       // Extension is valid but format is wrong (invalid characters between ID and extension)
-      errors.push('Virheellinen tiedostonimi. Sallittu muoto: {ID}.pääte tai {ID}K.pääte');
+      errors.push('Virheellinen tiedostonimi. Sallittu muoto: {ID}.pääte, {ID}K.pääte tai {ID}N.pääte (N=0-9)');
     }
     return { valid: false, errors };
   }

--- a/packages/server/lambdas/balise/__tests__/add-balise.test.ts
+++ b/packages/server/lambdas/balise/__tests__/add-balise.test.ts
@@ -86,7 +86,7 @@ describe('validateUploadedFiles', () => {
       expect(errors).toHaveLength(0);
     });
 
-    it('should reject files with invalid suffix (not K)', () => {
+    it('should reject files with invalid suffix (not K or digit)', () => {
       const files: ParsedFileUpload[] = [
         {
           filename: '12345X.il',
@@ -119,6 +119,62 @@ describe('validateUploadedFiles', () => {
       ];
       const errors = validateUploadedFiles(files, 12345);
       expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('Digit suffix validation', () => {
+    it('should accept files with single digit suffix (0-9)', () => {
+      const files: ParsedFileUpload[] = [
+        {
+          filename: '123454.il',
+          buffer: Buffer.from('test'),
+        },
+        {
+          filename: '123450.leu',
+          buffer: Buffer.from('test'),
+        },
+        {
+          filename: '123459.bis',
+          buffer: Buffer.from('test'),
+        },
+      ];
+      const errors = validateUploadedFiles(files, 12345);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject files with too many digits (7+ chars before extension)', () => {
+      const files: ParsedFileUpload[] = [
+        {
+          filename: '1234567.il',
+          buffer: Buffer.from('test'),
+        },
+      ];
+      const errors = validateUploadedFiles(files, 12345);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain('Virheellinen tiedostonimi');
+    });
+
+    it('should match digit suffix files to correct balise ID', () => {
+      const files: ParsedFileUpload[] = [
+        {
+          filename: '100034.il',
+          buffer: Buffer.from('test'),
+        },
+      ];
+      const errors = validateUploadedFiles(files, 10003);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject digit suffix files when balise ID does not match', () => {
+      const files: ParsedFileUpload[] = [
+        {
+          filename: '100034.il',
+          buffer: Buffer.from('test'),
+        },
+      ];
+      const errors = validateUploadedFiles(files, 10004);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain('baliisi-tunnus (10003)');
     });
   });
 

--- a/packages/server/lambdas/balise/__tests__/add-balise.test.ts
+++ b/packages/server/lambdas/balise/__tests__/add-balise.test.ts
@@ -172,7 +172,7 @@ describe('validateUploadedFiles', () => {
           buffer: Buffer.from('test'),
         },
       ];
-      const errors = validateUploadedFiles(files, 10004);
+      const errors = validateUploadedFiles(files, 100034);
       expect(errors).toHaveLength(1);
       expect(errors[0].error).toContain('baliisi-tunnus (10003)');
     });

--- a/packages/server/lambdas/balise/add-balise.ts
+++ b/packages/server/lambdas/balise/add-balise.ts
@@ -23,7 +23,7 @@ interface FileValidationError {
 
 /**
  * Validate uploaded files for a specific balise
- * - Filename must be in format {ID}.ext or {ID}K.ext (only K suffix allowed)
+ * - Filename must be in format {ID}.ext, {ID}K.ext, or {ID}{digit}.ext
  * - Extension must be .il, .leu, or .bis
  * - Balise ID in filename must match the target balise ID
  * - Balise ID must be between 10000-99999
@@ -43,7 +43,7 @@ export function validateUploadedFiles(files: ParsedFileUpload[], targetBaliseId:
       } else {
         errors.push({
           filename: file.filename,
-          error: 'Virheellinen tiedostonimi. Sallittu muoto: {ID}.pääte tai {ID}K.pääte',
+          error: 'Virheellinen tiedostonimi. Sallittu muoto: {ID}.pääte, {ID}K.pääte tai {ID}N.pääte (N=0-9)',
         });
       }
       continue;

--- a/packages/server/lambdas/balise/bulk-upload-balises.ts
+++ b/packages/server/lambdas/balise/bulk-upload-balises.ts
@@ -110,7 +110,7 @@ async function parseMultipartForm(
             log.warn({ system: true }, `Invalid file extension: ${fileinfo.filename}`);
           } else {
             invalidFiles.push(
-              `${fileinfo.filename} (virheellinen tiedostonimi, sallittu muoto: {ID}.pääte tai {ID}K.pääte)`,
+              `${fileinfo.filename} (virheellinen tiedostonimi, sallittu muoto: {ID}.pääte, {ID}K.pääte tai {ID}N.pääte (N=0-9))`,
             );
             log.warn({ system: true }, `Invalid filename format: ${fileinfo.filename}`);
           }

--- a/packages/server/utils/balise/__tests__/baliseUtils.test.ts
+++ b/packages/server/utils/balise/__tests__/baliseUtils.test.ts
@@ -441,9 +441,28 @@ describe('baliseUtils', () => {
       expect(parseBaliseIdFromFilename('12345K.IL')).toBe(12345);
     });
 
-    it('should return null for invalid suffix (only K allowed)', () => {
+    it('should parse digit suffix correctly (0-9)', () => {
+      expect(parseBaliseIdFromFilename('100034.il')).toBe(10003);
+      expect(parseBaliseIdFromFilename('100030.il')).toBe(10003);
+      expect(parseBaliseIdFromFilename('123459.leu')).toBe(12345);
+      expect(parseBaliseIdFromFilename('100001.bis')).toBe(10000);
+    });
+
+    it('should return null for invalid suffix (only K or digit allowed)', () => {
       expect(parseBaliseIdFromFilename('10003X.bis')).toBeNull();
       expect(parseBaliseIdFromFilename('10003AB.leu')).toBeNull();
+      expect(parseBaliseIdFromFilename('10003Z.il')).toBeNull();
+    });
+
+    it('should return null for too many characters after ID (7+ chars before dot)', () => {
+      expect(parseBaliseIdFromFilename('1234567.il')).toBeNull();
+      expect(parseBaliseIdFromFilename('10003K4.leu')).toBeNull();
+      expect(parseBaliseIdFromFilename('100034K.il')).toBeNull();
+    });
+
+    it('should return null for fewer than 5 digits', () => {
+      expect(parseBaliseIdFromFilename('1234.il')).toBeNull();
+      expect(parseBaliseIdFromFilename('999.leu')).toBeNull();
     });
 
     it('should return null for filename without numbers', () => {

--- a/packages/server/utils/balise/baliseUtils.ts
+++ b/packages/server/utils/balise/baliseUtils.ts
@@ -32,31 +32,33 @@ export function isValidBaliseIdRange(baliseId: number): boolean {
 
 /**
  * Parse balise ID from filename
- * Only allows format: {ID}.ext or {ID}K.ext (K suffix only, case insensitive)
+ * Allows format: {5-digit ID}.ext, {5-digit ID}K.ext, or {5-digit ID}{digit}.ext
+ * The suffix can be K/k or a single digit 0-9 (case insensitive for K)
  * Examples:
  *   "10000.il" → 10000
  *   "10000.leu" → 10000
  *   "12345.bis" → 12345
  *   "10000K.il" → 10000
  *   "10000k.LEU" → 10000
- *   "10000X.il" → null (invalid - only K allowed)
+ *   "100034.il" → 10003
+ *   "100030.il" → 10003
+ *   "10000X.il" → null (invalid - only K or digit allowed)
  */
 export function parseBaliseIdFromFilename(filename: string): number | null {
-  // Match: digits, optionally followed by K/k, then a dot and extension
-  // This ensures only K suffix is allowed after the ID
-  const match = filename.match(/^(\d+)[Kk]?\.(il|leu|bis)$/i);
+  // Match: exactly 5 digits (the ID), optionally followed by K/k or a single digit, then a dot and extension
+  const match = filename.match(/^(\d{5})[Kk\d]?\.(il|leu|bis)$/i);
   if (!match) return null;
   const id = parseInt(match[1], 10);
   return isNaN(id) ? null : id;
 }
 
 /**
- * Check if filename has valid format (ID with optional K suffix + valid extension)
+ * Check if filename has valid format (5-digit ID with optional K or digit suffix + valid extension)
  * Returns false if there are invalid characters between ID and extension
  */
 export function isValidFilenameFormat(filename: string): boolean {
-  // Valid format: {digits}{optional K/k}.{il|leu|bis} (case insensitive for extension)
-  return /^(\d+)[Kk]?\.(il|leu|bis)$/i.test(filename);
+  // Valid format: {5 digits}{optional K/k or digit}.{il|leu|bis} (case insensitive for extension)
+  return /^(\d{5})[Kk\d]?\.(il|leu|bis)$/i.test(filename);
 }
 
 export interface BaliseUpdateResult {


### PR DESCRIPTION
- Allow six digit balise files through validation
- Treat sixth balise digit as suffix (similar to K-suffix previously)
- Match six digit balise files to balise ID based on first 5 digits (eg 100031.il -> balise ID 10003)